### PR TITLE
fix: Rollback Doctrine updates due to breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "require": {
         "php": "^8.2",
         "composer/composer": "~2.2",
-        "doctrine/annotations": "~2.0",
-        "doctrine/dbal": "^3.8",
-        "doctrine/cache": "^2.2",
+        "doctrine/annotations": "~1.14",
+        "doctrine/dbal": "~2.13",
+        "doctrine/cache": "~1.13",
         "paragonie/random-lib": "~2.0.1",
         "paragonie/sodium_compat": "~1.21",
         "php-debugbar/php-debugbar": "~1.23",


### PR DESCRIPTION
This PR rolls back the Doctrine updates (dbal, cache, annotations) that were causing breaking changes. 

## Changes:
- Reverted doctrine/dbal from ^3.8 back to ~2.13
- Reverted doctrine/cache from ^2.2 back to ~1.13  
- Reverted doctrine/annotations from ~2.0 back to ~1.14

## Reason:
These updates introduced breaking changes that require more preparation work:
1. First need to migrate from Doctrine Annotations to PHP 8 Attributes
2. Then we can safely update Doctrine packages

## Next Steps:
- Implement Doctrine Annotations to Attributes migration (Step 1.3.6)
- Then update Doctrine packages (Step 1.3.7)