### PR TITLE
feat(validation): complete symfony validator migration

### DIFF
--- a/.cursor/rules/pagekit-context.mdc
+++ b/.cursor/rules/pagekit-context.mdc
@@ -25,6 +25,18 @@ alwaysApply: true
     - Use **Return Types** (`: void`, `: ?array`).
     - Use **Constructor Property Promotion** where readable.
 
+## 🚀 AGGRESSIVE MODERNIZATION RULES
+
+1. **NO COMPATIBILITY LAYERS** – do not keep old & new behavior in parallel.
+2. **NO ADAPTERS** – update all call sites instead of adding wrappers.
+3. **BREAKING CHANGES ALLOWED INTERNALLY** – as long as public behavior (HTTP/API) stays the same.
+4. **DELETE OVER WRAP** – if old logic conflicts with the new security model, delete it.
+5. **LEGACY HACKS MUST BE MARKED** – use `// TODO: Must be refactored later` for unavoidable hacks.
+6. **HONEST COMMENTS** – Comments must reflect reality. If something IS backward compatibility, 
+   mark it clearly with `// TODO: BACKWARD COMPATIBILITY - Must be refactored later` prefix so it can be refactored per rules 1-5. 
+   Don't hide backward compatibility by removing the word from comments. Explain WHY code works 
+   this way, not what it replaces (unless it's temporary backward compatibility that needs removal).
+
 ## 🛠 Technology Stack (Modernization Phase)
 
 ### Backend (Active)

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -67,6 +67,13 @@
 - **Manual validation in controllers removed** - All validation now uses Symfony Validator
 - Internal API changes for cleaner PHP 8 code (Rule #3: BREAKING CHANGES ALLOWED)
 
+### 🔧 Fixes
+
+- **URL field normalization** - Fixed optional URL fields in User and Comment models (empty strings converted to null for Symfony Url constraint compatibility)
+- **Case-insensitive uniqueness validation** - Updated UniqueValidator to use SQL LOWER() for case-insensitive comparison
+- **Validation group handling** - Fixed RegistrationController to explicitly include 'Default' validation group
+- **Modernization rules documentation** - Added aggressive modernization rules to project context (NO COMPATIBILITY LAYERS, NO ADAPTERS, DELETE OVER WRAP)
+
 ### 📚 Documentation
 
 - **VALIDATION_SYSTEM.md** - Comprehensive documentation in `migration-docs/branches/`

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -10,6 +10,7 @@
   - ✅ No compatibility layers - aggressive modernization per project rules
   - ✅ Phase 1: User module (User, Role entities)
   - ✅ Phase 2: Site module (Node, Page entities), Widget module (Widget entity)
+  - ✅ Phase 3: Comment module (base), Blog package (Post, Comment entities)
 
 ### ✨ New Features
 
@@ -50,6 +51,15 @@
   - `Widget` entity: Title, type, status validation
   - Controller: `WidgetApiController` with ValidatesRequestTrait
   - Removed manual 'Widget title empty' check
+
+- **Comment Module** (Phase 3)
+  - Base `Comment` entity (abstract): Author, content, status validation
+
+- **Blog Package** (Phase 3)
+  - `Post` entity: Title, slug, status, user_id, comment_count validation
+  - `Comment` entity: Email, url, post_id validation (extends base Comment)
+  - Controllers: `PostApiController`, `CommentApiController` with ValidatesRequestTrait
+  - Removed manual 'Invalid slug' validation check
 
 ### 📝 Breaking Changes
 
@@ -98,6 +108,14 @@
 - `app/system/modules/site/src/Controller/NodeApiController.php`
 - `app/system/modules/widget/src/Model/Widget.php`
 - `app/system/modules/widget/src/Controller/WidgetApiController.php`
+
+**Files Modified (Phase 3):**
+- `app/system/languages/en_US/validation.php` (added Blog/Comment messages)
+- `app/system/modules/comment/src/Model/Comment.php` (base Comment entity)
+- `packages/pagekit/blog/src/Model/Post.php`
+- `packages/pagekit/blog/src/Model/Comment.php`
+- `packages/pagekit/blog/src/Controller/PostApiController.php`
+- `packages/pagekit/blog/src/Controller/CommentApiController.php`
 
 **Aggressive Modernization Rules Applied:**
 - Rule #1: NO COMPATIBILITY LAYERS - No shim classes created

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -8,6 +8,8 @@
   - ✅ Added `symfony/validator` ^7.4 for modern PHP 8 Attribute-based validation
   - ✅ Hybrid approach: Validation uses Attributes, ORM still uses Doctrine Annotations (until Step 1.14)
   - ✅ No compatibility layers - aggressive modernization per project rules
+  - ✅ Phase 1: User module (User, Role entities)
+  - ✅ Phase 2: Site module (Node, Page entities), Widget module (Widget entity)
 
 ### ✨ New Features
 
@@ -25,28 +27,34 @@
   - Uses Pagekit's QueryBuilder (DBAL 3.x compatible)
   - Supports update context (excludes current record by ID)
 
+- **Centralized Validation Messages** (Phase 2)
+  - Created `app/system/languages/en_US/validation.php`
+  - All validation messages referenced by key for future translation
+  - Message keys follow pattern: `validation.{module}.{field}_{constraint}`
+
 ### 🔄 Refactored
 
-- **User Entity Validation** - Complete rewrite with Symfony Validator
-  - Added `#[Assert\NotBlank]`, `#[Assert\Email]`, `#[Assert\Length]`, `#[Assert\Regex]` attributes
-  - Added `#[PagekitAssert\Unique]` for username and email uniqueness
+- **User Module** (Phase 1)
+  - `User` entity: Full validation with `#[Assert\...]` and `#[PagekitAssert\Unique]`
+  - `Role` entity: Name and priority validation
+  - Controllers: `UserApiController`, `RegistrationController`, `ProfileController`, `RoleApiController`
   - **REMOVED** old `validate()` method (Rule #4: DELETE OVER WRAP)
-  - ORM annotations preserved with TODO markers for Step 1.14
 
-- **Role Entity Validation** - Added Symfony Validator attributes
-  - `#[Assert\NotBlank]` for name
-  - `#[Assert\Length]` for name constraints
-  - `#[Assert\PositiveOrZero]` for priority
+- **Site Module** (Phase 2)
+  - `Node` entity: Slug, title, link, type, status, priority validation
+  - `Page` entity: Title validation
+  - Controller: `NodeApiController` with ValidatesRequestTrait
+  - Removed manual slug/link validation checks
 
-- **Controller Updates** - All user controllers modernized
-  - `UserApiController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
-  - `RegistrationController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
-  - `ProfileController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
-  - Added `declare(strict_types=1)` to all controllers
+- **Widget Module** (Phase 2)
+  - `Widget` entity: Title, type, status validation
+  - Controller: `WidgetApiController` with ValidatesRequestTrait
+  - Removed manual 'Widget title empty' check
 
 ### 📝 Breaking Changes
 
 - **User::validate() method removed** - Replace all calls with `$this->validateOrFail($user)` using `ValidatesRequestTrait`
+- **Manual validation in controllers removed** - All validation now uses Symfony Validator
 - Internal API changes for cleaner PHP 8 code (Rule #3: BREAKING CHANGES ALLOWED)
 
 ### 📚 Documentation
@@ -57,17 +65,24 @@
   - All validation constraints documented
   - Error response format for Vue.js frontend
   - Migration guide from manual validation
+  - Message key reference
+
+- **VALIDATION_PHASE2_DISCOVERY.md** - Migration checklist and discovery document
 
 ### 🔧 Technical Details
 
-**Files Created:**
+**Files Created (Phase 1):**
 - `app/system/src/ValidatorServiceProvider.php`
 - `app/system/src/Controller/ValidatesRequestTrait.php`
 - `app/system/src/Validator/Constraints/Unique.php`
 - `app/system/src/Validator/Constraints/UniqueValidator.php`
 - `migration-docs/branches/VALIDATION_SYSTEM.md`
 
-**Files Modified:**
+**Files Created (Phase 2):**
+- `app/system/languages/en_US/validation.php`
+- `migration-docs/branches/VALIDATION_PHASE2_DISCOVERY.md`
+
+**Files Modified (Phase 1):**
 - `composer.json` (added symfony/validator)
 - `app/system/index.php` (registered validator service)
 - `app/system/modules/user/src/Model/User.php`
@@ -76,11 +91,19 @@
 - `app/system/modules/user/src/Controller/RegistrationController.php`
 - `app/system/modules/user/src/Controller/ProfileController.php`
 
+**Files Modified (Phase 2):**
+- `app/system/modules/user/src/Controller/RoleApiController.php`
+- `app/system/modules/site/src/Model/Node.php`
+- `app/system/modules/site/src/Model/Page.php`
+- `app/system/modules/site/src/Controller/NodeApiController.php`
+- `app/system/modules/widget/src/Model/Widget.php`
+- `app/system/modules/widget/src/Controller/WidgetApiController.php`
+
 **Aggressive Modernization Rules Applied:**
 - Rule #1: NO COMPATIBILITY LAYERS - No shim classes created
 - Rule #2: NO ADAPTERS - All controller usages updated in same commit
 - Rule #3: BREAKING CHANGES ALLOWED - Internal API changed for cleaner code
-- Rule #4: DELETE OVER WRAP - Old `validate()` method completely removed
+- Rule #4: DELETE OVER WRAP - Old `validate()` method and manual checks completely removed
 - Rule #5: MANDATORY FLAGGING - All ORM annotations marked with TODO for Step 1.14
 
 ---

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -1,5 +1,90 @@
 # Changelog 2025
 
+## Pagekit 1.0.46 - Symfony Validator Integration (January 19, 2026)
+
+### 🚀 Major Changes
+
+- **Symfony Validator Integration (Step 1.13 - Hybrid Mode)** - Complete migration from manual validation to Symfony Validator with PHP 8 Attributes
+  - ✅ Added `symfony/validator` ^7.4 for modern PHP 8 Attribute-based validation
+  - ✅ Hybrid approach: Validation uses Attributes, ORM still uses Doctrine Annotations (until Step 1.14)
+  - ✅ No compatibility layers - aggressive modernization per project rules
+
+### ✨ New Features
+
+- **ValidatorServiceProvider** - New service provider for Symfony Validator integration
+  - Registers `$app['validator']` service with PHP 8 Attribute support enabled
+  - Registered during boot event in `app/system/index.php`
+
+- **ValidatesRequestTrait** - Standardized controller validation
+  - `validate($object)` - Returns `JsonResponse` on failure, `null` on success
+  - `validateOrFail($object)` - Throws `Exception` on failure
+  - Consistent JSON error format for Vue.js frontend integration
+
+- **Custom Unique Constraint** - Database uniqueness validation
+  - `#[PagekitAssert\Unique]` attribute for entity properties
+  - Uses Pagekit's QueryBuilder (DBAL 3.x compatible)
+  - Supports update context (excludes current record by ID)
+
+### 🔄 Refactored
+
+- **User Entity Validation** - Complete rewrite with Symfony Validator
+  - Added `#[Assert\NotBlank]`, `#[Assert\Email]`, `#[Assert\Length]`, `#[Assert\Regex]` attributes
+  - Added `#[PagekitAssert\Unique]` for username and email uniqueness
+  - **REMOVED** old `validate()` method (Rule #4: DELETE OVER WRAP)
+  - ORM annotations preserved with TODO markers for Step 1.14
+
+- **Role Entity Validation** - Added Symfony Validator attributes
+  - `#[Assert\NotBlank]` for name
+  - `#[Assert\Length]` for name constraints
+  - `#[Assert\PositiveOrZero]` for priority
+
+- **Controller Updates** - All user controllers modernized
+  - `UserApiController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
+  - `RegistrationController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
+  - `ProfileController` - Uses `ValidatesRequestTrait`, `$this->validateOrFail($user)`
+  - Added `declare(strict_types=1)` to all controllers
+
+### 📝 Breaking Changes
+
+- **User::validate() method removed** - Replace all calls with `$this->validateOrFail($user)` using `ValidatesRequestTrait`
+- Internal API changes for cleaner PHP 8 code (Rule #3: BREAKING CHANGES ALLOWED)
+
+### 📚 Documentation
+
+- **VALIDATION_SYSTEM.md** - Comprehensive documentation in `migration-docs/branches/`
+  - Hybrid approach explanation (Attributes for validation, Annotations for ORM)
+  - Usage guide for ValidatesRequestTrait
+  - All validation constraints documented
+  - Error response format for Vue.js frontend
+  - Migration guide from manual validation
+
+### 🔧 Technical Details
+
+**Files Created:**
+- `app/system/src/ValidatorServiceProvider.php`
+- `app/system/src/Controller/ValidatesRequestTrait.php`
+- `app/system/src/Validator/Constraints/Unique.php`
+- `app/system/src/Validator/Constraints/UniqueValidator.php`
+- `migration-docs/branches/VALIDATION_SYSTEM.md`
+
+**Files Modified:**
+- `composer.json` (added symfony/validator)
+- `app/system/index.php` (registered validator service)
+- `app/system/modules/user/src/Model/User.php`
+- `app/system/modules/user/src/Model/Role.php`
+- `app/system/modules/user/src/Controller/UserApiController.php`
+- `app/system/modules/user/src/Controller/RegistrationController.php`
+- `app/system/modules/user/src/Controller/ProfileController.php`
+
+**Aggressive Modernization Rules Applied:**
+- Rule #1: NO COMPATIBILITY LAYERS - No shim classes created
+- Rule #2: NO ADAPTERS - All controller usages updated in same commit
+- Rule #3: BREAKING CHANGES ALLOWED - Internal API changed for cleaner code
+- Rule #4: DELETE OVER WRAP - Old `validate()` method completely removed
+- Rule #5: MANDATORY FLAGGING - All ORM annotations marked with TODO for Step 1.14
+
+---
+
 ## Pagekit 1.0.45 - Database Migration System Improvements (January 17, 2026)
 
 ### 🐛 Fixed

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.0.45'
+        'version' => '1.0.46'
 
     ],
 

--- a/app/system/index.php
+++ b/app/system/index.php
@@ -81,6 +81,10 @@ return [
 
         'boot' => function ($event, $app) {
 
+            // Register Symfony Validator service (Step 1.13 - Hybrid Mode)
+            // Uses PHP 8 Attributes for validation while ORM still uses Doctrine Annotations
+            \Pagekit\System\ValidatorServiceProvider::register($app);
+
             if (!$app['debug']) {
                 $app->subscribe(new ExceptionListener('Pagekit\System\Controller\ExceptionController::showAction'));
             }

--- a/app/system/languages/en_US/validation.php
+++ b/app/system/languages/en_US/validation.php
@@ -1,9 +1,11 @@
 <?php
 
 /**
- * Validation Messages for Symfony Validator (Step 1.13 - Hybrid Mode)
+ * System Validation Messages for Symfony Validator (Step 1.13 - Hybrid Mode)
  *
- * This file contains all validation message keys used with Symfony Validator attributes.
+ * This file contains validation message keys for SYSTEM modules only.
+ * Extension packages (e.g., Blog) have their own validation.php files.
+ *
  * These keys are referenced in entity validation constraints via the 'message' parameter.
  *
  * Example usage in entity:
@@ -103,36 +105,12 @@ return [
     // COMMENT MODULE (Base)
     // ============================================================
 
-    // Comment Entity (base class)
+    // Comment Entity (base class for extensions to inherit)
     'validation.comment.author_required' => 'Author name is required.',
     'validation.comment.author_max_length' => 'Author name cannot exceed {{ limit }} characters.',
 
     'validation.comment.content_required' => 'Comment content is required.',
 
     'validation.comment.status_invalid' => 'Invalid comment status.',
-
-    // ============================================================
-    // BLOG PACKAGE
-    // ============================================================
-
-    // Post Entity
-    'validation.post.title_required' => 'Post title is required.',
-    'validation.post.title_max_length' => 'Post title cannot exceed {{ limit }} characters.',
-
-    'validation.post.slug_required' => 'Slug is required.',
-    'validation.post.slug_invalid' => 'Invalid slug. Only lowercase letters, numbers, hyphens and underscores are allowed.',
-    'validation.post.slug_max_length' => 'Slug cannot exceed {{ limit }} characters.',
-
-    'validation.post.status_invalid' => 'Invalid post status.',
-
-    'validation.post.user_required' => 'Author is required.',
-
-    // Blog Comment Entity (extends base Comment)
-    'validation.blog_comment.email_required' => 'Email is required.',
-    'validation.blog_comment.email_invalid' => 'Please provide a valid email address.',
-
-    'validation.blog_comment.post_required' => 'Post is required.',
-
-    'validation.blog_comment.url_invalid' => 'URL is invalid.',
 
 ];

--- a/app/system/languages/en_US/validation.php
+++ b/app/system/languages/en_US/validation.php
@@ -99,4 +99,40 @@ return [
 
     'validation.widget.status_invalid' => 'Invalid widget status.',
 
+    // ============================================================
+    // COMMENT MODULE (Base)
+    // ============================================================
+
+    // Comment Entity (base class)
+    'validation.comment.author_required' => 'Author name is required.',
+    'validation.comment.author_max_length' => 'Author name cannot exceed {{ limit }} characters.',
+
+    'validation.comment.content_required' => 'Comment content is required.',
+
+    'validation.comment.status_invalid' => 'Invalid comment status.',
+
+    // ============================================================
+    // BLOG PACKAGE
+    // ============================================================
+
+    // Post Entity
+    'validation.post.title_required' => 'Post title is required.',
+    'validation.post.title_max_length' => 'Post title cannot exceed {{ limit }} characters.',
+
+    'validation.post.slug_required' => 'Slug is required.',
+    'validation.post.slug_invalid' => 'Invalid slug. Only lowercase letters, numbers, hyphens and underscores are allowed.',
+    'validation.post.slug_max_length' => 'Slug cannot exceed {{ limit }} characters.',
+
+    'validation.post.status_invalid' => 'Invalid post status.',
+
+    'validation.post.user_required' => 'Author is required.',
+
+    // Blog Comment Entity (extends base Comment)
+    'validation.blog_comment.email_required' => 'Email is required.',
+    'validation.blog_comment.email_invalid' => 'Please provide a valid email address.',
+
+    'validation.blog_comment.post_required' => 'Post is required.',
+
+    'validation.blog_comment.url_invalid' => 'URL is invalid.',
+
 ];

--- a/app/system/languages/en_US/validation.php
+++ b/app/system/languages/en_US/validation.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Validation Messages for Symfony Validator (Step 1.13 - Hybrid Mode)
+ *
+ * This file contains all validation message keys used with Symfony Validator attributes.
+ * These keys are referenced in entity validation constraints via the 'message' parameter.
+ *
+ * Example usage in entity:
+ * #[Assert\NotBlank(message: 'validation.user.username_required')]
+ *
+ * Note: Actual translation integration (using __() function or Symfony Translator)
+ * will be handled in a later phase. For now, these are English messages only.
+ */
+
+return [
+
+    // ============================================================
+    // GENERIC VALIDATION MESSAGES
+    // ============================================================
+
+    'validation.required' => 'This field is required.',
+    'validation.email' => 'This value is not a valid email address.',
+    'validation.url' => 'This value is not a valid URL.',
+    'validation.min_length' => 'This value is too short. It should have {{ limit }} characters or more.',
+    'validation.max_length' => 'This value is too long. It should have {{ limit }} characters or fewer.',
+    'validation.length' => 'This value should be between {{ min }} and {{ max }} characters.',
+    'validation.unique' => 'This value already exists.',
+    'validation.regex' => 'This value is not valid.',
+    'validation.choice' => 'The value you selected is not a valid choice.',
+    'validation.positive_or_zero' => 'This value should be either positive or zero.',
+
+    // ============================================================
+    // USER MODULE
+    // ============================================================
+
+    // User Entity
+    'validation.user.username_required' => 'Username is required.',
+    'validation.user.username_min_length' => 'Username must be at least {{ limit }} characters.',
+    'validation.user.username_max_length' => 'Username cannot exceed {{ limit }} characters.',
+    'validation.user.username_invalid' => 'Username is invalid. Only letters, numbers, dots, underscores and hyphens are allowed.',
+    'validation.user.username_not_available' => 'Username is not available.',
+
+    'validation.user.password_required' => 'Password is required.',
+
+    'validation.user.email_required' => 'Email is required.',
+    'validation.user.email_invalid' => 'Email is invalid.',
+    'validation.user.email_not_available' => 'Email is not available.',
+
+    'validation.user.name_required' => 'Name is required.',
+    'validation.user.name_max_length' => 'Name cannot exceed {{ limit }} characters.',
+
+    'validation.user.url_invalid' => 'URL is invalid.',
+
+    'validation.user.status_invalid' => 'Invalid status.',
+
+    // Role Entity
+    'validation.role.name_required' => 'Role name is required.',
+    'validation.role.name_min_length' => 'Role name must be at least {{ limit }} characters.',
+    'validation.role.name_max_length' => 'Role name cannot exceed {{ limit }} characters.',
+    'validation.role.priority_invalid' => 'Priority must be a non-negative number.',
+
+    // ============================================================
+    // SITE MODULE
+    // ============================================================
+
+    // Node Entity
+    'validation.node.slug_required' => 'Slug is required.',
+    'validation.node.slug_invalid' => 'Invalid slug. Only lowercase letters, numbers, hyphens and underscores are allowed.',
+    'validation.node.slug_max_length' => 'Slug cannot exceed {{ limit }} characters.',
+
+    'validation.node.title_required' => 'Title is required.',
+    'validation.node.title_max_length' => 'Title cannot exceed {{ limit }} characters.',
+
+    'validation.node.link_max_length' => 'Link cannot exceed {{ limit }} characters.',
+
+    'validation.node.type_required' => 'Node type is required.',
+
+    'validation.node.status_invalid' => 'Invalid status.',
+
+    'validation.node.priority_invalid' => 'Priority must be a non-negative number.',
+
+    // Page Entity
+    'validation.page.title_required' => 'Page title is required.',
+    'validation.page.title_max_length' => 'Page title cannot exceed {{ limit }} characters.',
+
+    // Menu (not entity validation, but business logic messages)
+    'validation.menu.id_invalid' => 'Invalid menu id.',
+
+    // ============================================================
+    // WIDGET MODULE
+    // ============================================================
+
+    // Widget Entity
+    'validation.widget.title_required' => 'Widget title is required.',
+    'validation.widget.title_max_length' => 'Widget title cannot exceed {{ limit }} characters.',
+
+    'validation.widget.type_required' => 'Widget type is required.',
+
+    'validation.widget.status_invalid' => 'Invalid widget status.',
+
+];

--- a/app/system/modules/comment/src/Model/Comment.php
+++ b/app/system/modules/comment/src/Model/Comment.php
@@ -4,33 +4,68 @@ declare(strict_types=1);
 
 namespace Pagekit\Comment\Model;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 /**
+ * Base Comment entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@MappedSuperclass, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @MappedSuperclass
  */
 abstract class Comment
 {
     use CommentModelTrait;
 
-    const STATUS_PENDING = 0;
-    const STATUS_APPROVED = 1;
-    const STATUS_SPAM = 2;
+    public const STATUS_PENDING = 0;
+    public const STATUS_APPROVED = 1;
+    public const STATUS_SPAM = 2;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column(type="text") */
+    /**
+     * @Column(type="text")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.comment.content_required')]
     public ?string $content = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.comment.author_required')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.comment.author_max_length'
+    )]
     public ?string $author = null;
 
-    /** @Column(type="datetime") */
+    /**
+     * @Column(type="datetime")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public \DateTime $created;
 
-    /** @Column(type="smallint") */
+    /**
+     * @Column(type="smallint")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Choice(
+        choices: [self::STATUS_PENDING, self::STATUS_APPROVED, self::STATUS_SPAM],
+        message: 'validation.comment.status_invalid'
+    )]
     public int $status = 0;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $parent_id = null;
 
     /**

--- a/app/system/modules/site/src/Controller/NodeApiController.php
+++ b/app/system/modules/site/src/Controller/NodeApiController.php
@@ -88,13 +88,18 @@ class NodeApiController
         // Apply slug filter - this is business logic that generates a valid slug
         $data['slug'] = App::filter($slug ?: $title, 'slugify');
 
-        $node->save($data);
+        // Assign data to entity for validation (without saving yet)
+        foreach ($data as $key => $value) {
+            if (property_exists($node, $key)) {
+                $node->$key = $value;
+            }
+        }
 
         // Validate using Symfony Validator (replaces manual slug/link validation)
         // Rule #4: DELETE OVER WRAP - old manual checks removed
         $this->validateOrFail($node);
 
-        $node->save();
+        $node->save($data);
 
         return ['message' => 'success', 'node' => $node];
     }

--- a/app/system/modules/site/src/Controller/NodeApiController.php
+++ b/app/system/modules/site/src/Controller/NodeApiController.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\Site\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Site\Model\Node;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use function Pagekit\__;
 
 /**
+ * API Controller for Node management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Access("site: manage site")
  */
 class NodeApiController
 {
+    use ValidatesRequestTrait;
+
     /**
      * @Route("/", methods="GET")
      */
@@ -18,7 +27,7 @@ class NodeApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $menu = App::request()->query->get('menu', false);
-        
+
         $query = Node::query();
 
         if (is_string($menu)) {
@@ -31,7 +40,7 @@ class NodeApiController
     /**
      * @Route("/{id}", methods="GET", requirements={"id"="\d+"})
      */
-    public function getAction($id): Node
+    public function getAction(int $id): Node
     {
         if (!$node = Node::find($id)) {
             App::abort(404, __('Node not found.'));
@@ -41,15 +50,19 @@ class NodeApiController
     }
 
     /**
+     * Save a node (create or update).
+     *
+     * Uses Symfony Validator for validation (replaces manual slug/link validation).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      */
-    public function saveAction($id = 0, $data = null): array
+    public function saveAction(int $id = 0, ?array $data = null): array
     {
         // Get parameters from request if not provided (Symfony 6.4 compatibility)
         if ($data === null) {
             $request = App::request();
-            
+
             // Get node data from POST or JSON body
             $data = $request->request->all()['node'] ?? [];
             if (empty($data) && $request->getContent()) {
@@ -57,32 +70,31 @@ class NodeApiController
                 $data = $json['node'] ?? $json ?? [];
             }
         }
-        
+
         // Get id from route or data
         if (!$id && isset($data['id'])) {
             $id = (int) $data['id'];
         }
-        
+
         if (!$node = Node::find($id)) {
             $node = Node::create();
             unset($data['id']);
         }
 
-        // Generate slug from title if not provided
+        // Generate slug from title if not provided (business logic, not validation)
         $slug = isset($data['slug']) ? $data['slug'] : '';
         $title = isset($data['title']) ? $data['title'] : '';
-        
-        if (!$data['slug'] = App::filter($slug ?: $title, 'slugify')) {
-            App::abort(400, __('Invalid slug.'));
-        }
 
-        // Validate link field only for existing nodes where it's explicitly empty
-        // For new nodes, the model's @Saving hook will set a default value
-        if ($node->id && isset($data['link']) && trim($data['link']) === '') {
-            App::abort(400, __('Link is required. Please specify a valid URL or route.'));
-        }
+        // Apply slug filter - this is business logic that generates a valid slug
+        $data['slug'] = App::filter($slug ?: $title, 'slugify');
 
         $node->save($data);
+
+        // Validate using Symfony Validator (replaces manual slug/link validation)
+        // Rule #4: DELETE OVER WRAP - old manual checks removed
+        $this->validateOrFail($node);
+
+        $node->save();
 
         return ['message' => 'success', 'node' => $node];
     }
@@ -90,15 +102,16 @@ class NodeApiController
     /**
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      */
-    public function deleteAction($id = 0): array
+    public function deleteAction(int $id = 0): array
     {
         // Get id from route if not provided (Symfony 6.4 compatibility)
         if (!$id) {
             $id = (int) App::request()->get('id', 0);
         }
-        
+
         if ($node = Node::find($id)) {
 
+            // Business logic: Check if node type is protected (NOT entity validation)
             if ($type = App::module('system/site')->getType($node->type) and isset($type['protected']) and $type['protected']) {
                 App::abort(400, __('Invalid type.'));
             }
@@ -116,14 +129,14 @@ class NodeApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         // Get nodes data from POST or JSON body
         $nodes = $request->request->all()['nodes'] ?? [];
         if (empty($nodes) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $nodes = $json['nodes'] ?? [];
         }
-        
+
         foreach ($nodes as $data) {
             // Call saveAction with each node's id and data
             $id = isset($data['id']) ? $data['id'] : 0;
@@ -140,14 +153,14 @@ class NodeApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         // Get ids from POST/DELETE body or JSON
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);
         }
@@ -162,10 +175,10 @@ class NodeApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $menu = $request->request->get('menu', '');
         $nodes = $request->request->all()['nodes'] ?? [];
-        
+
         if ($request->getContent()) {
             $json = json_decode($request->getContent(), true);
             if ($json) {
@@ -173,7 +186,7 @@ class NodeApiController
                 $nodes = $json['nodes'] ?? $nodes;
             }
         }
-        
+
         foreach ($nodes as $data) {
 
             if ($node = Node::find($data['id'])) {
@@ -196,17 +209,18 @@ class NodeApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $id = (int) $request->request->get('id', 0);
         if (!$id && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $id = (int) ($json['id'] ?? 0);
         }
-        
+
         if (!$node = Node::find($id) or !$type = App::module('system/site')->getType($node->type)) {
             App::abort(404, __('Node not found.'));
         }
 
+        // Business logic: Check if node type is allowed as frontpage (NOT entity validation)
         if (isset($type['frontpage']) and !$type['frontpage']) {
             App::abort(400, __('Invalid node type.'));
         }

--- a/app/system/modules/site/src/Model/Node.php
+++ b/app/system/modules/site/src/Model/Node.php
@@ -10,8 +10,14 @@ use Pagekit\System\Model\NodeInterface;
 use Pagekit\System\Model\NodeTrait;
 use Pagekit\User\Model\AccessModelTrait;
 use Pagekit\User\Model\User;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * Node entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@system_node")
  */
 #[\AllowDynamicProperties]
@@ -19,34 +25,89 @@ class Node implements NodeInterface, \JsonSerializable
 {
     use AccessModelTrait, DataModelTrait, NodeModelTrait, NodeTrait;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\PositiveOrZero(message: 'validation.node.priority_invalid')]
     public ?int $parent_id = 0;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\PositiveOrZero(message: 'validation.node.priority_invalid')]
     public int $priority = 0;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Choice(
+        choices: [0, 1],
+        message: 'validation.node.status_invalid'
+    )]
     public int $status = 0;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.node.slug_required')]
+    #[Assert\Regex(
+        pattern: '/^[a-z0-9\-_]+$/',
+        message: 'validation.node.slug_invalid'
+    )]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.node.slug_max_length'
+    )]
     public ?string $slug = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $path = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Length(
+        max: 500,
+        maxMessage: 'validation.node.link_max_length'
+    )]
     public ?string $link = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.node.title_required')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.node.title_max_length'
+    )]
     public ?string $title = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.node.type_required')]
     public ?string $type = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $menu = '';
 
     protected static array $properties = [

--- a/app/system/modules/site/src/Model/Page.php
+++ b/app/system/modules/site/src/Model/Page.php
@@ -6,20 +6,40 @@ namespace Pagekit\Site\Model;
 
 use Pagekit\Database\ORM\ModelTrait;
 use Pagekit\System\Model\DataModelTrait;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * Page entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@system_page")
  */
 class Page implements \JsonSerializable
 {
     use DataModelTrait, ModelTrait;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.page.title_required')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.page.title_max_length'
+    )]
     public ?string $title = null;
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $content = '';
 }

--- a/app/system/modules/user/src/Controller/ProfileController.php
+++ b/app/system/modules/user/src/Controller/ProfileController.php
@@ -1,14 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\User\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Application\Exception;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\User\Model\User;
 use function Pagekit\__;
 
+/**
+ * Controller for user profile management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ */
 class ProfileController
 {
+    use ValidatesRequestTrait;
+
     public function indexAction()
     {
         $user = App::user();
@@ -32,9 +42,13 @@ class ProfileController
     }
 
     /**
+     * Save user profile changes.
+     *
+     * Uses Symfony Validator for validation (replaces old $user->validate() method).
+     *
      * @Request({"user": "array"}, csrf=true)
      */
-    public function saveAction($data)
+    public function saveAction(array $data)
     {
         $user = App::user();
 
@@ -66,7 +80,10 @@ class ProfileController
             $user->name = @$data['name'];
             $user->email = @$data['email'];
 
-            $user->validate();
+            // Validate using Symfony Validator (replaces old $user->validate() call)
+            // Rule #4: DELETE OVER WRAP - old validate() method has been removed
+            $this->validateOrFail($user);
+
             $user->save();
 
             return ['message' => 'success'];

--- a/app/system/modules/user/src/Controller/RegistrationController.php
+++ b/app/system/modules/user/src/Controller/RegistrationController.php
@@ -1,15 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\User\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Application\Exception;
 use Pagekit\Module\Module;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\User\Model\User;
 use function Pagekit\__;
 
+/**
+ * Controller for user registration.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ */
 class RegistrationController
 {
+    use ValidatesRequestTrait;
+
     protected Module $module;
 
     public function __construct()
@@ -39,10 +49,14 @@ class RegistrationController
     }
 
     /**
+     * Register a new user.
+     *
+     * Uses Symfony Validator for validation (replaces old $user->validate() method).
+     *
      * @Request({"user": "array"})
      * @Captcha(verify="true")
      */
-    public function registerAction($data)
+    public function registerAction(array $data)
     {
         try {
 
@@ -78,7 +92,11 @@ class RegistrationController
                 $user->status = User::STATUS_ACTIVE;
             }
 
-            $user->validate();
+            // Validate using Symfony Validator (replaces old $user->validate() call)
+            // Rule #4: DELETE OVER WRAP - old validate() method has been removed
+            // Use 'registration' validation group to include password validation
+            $this->validateOrFail($user);
+
             $user->save();
 
             if ($verify) {
@@ -106,7 +124,7 @@ class RegistrationController
     /**
      * @Request({"user", "key"})
      */
-    public function activateAction($username, $activation)
+    public function activateAction(string $username, string $activation)
     {
         if (empty($username) || empty($activation) || !$user = User::where(['username' => $username, 'activation' => $activation, 'login IS NULL'])->first()) {
             App::abort(400, __('Invalid key.'));
@@ -137,7 +155,7 @@ class RegistrationController
         return App::redirect('@user/login');
     }
 
-    protected function sendWelcomeEmail($user): void
+    protected function sendWelcomeEmail(User $user): void
     {
         try {
 
@@ -151,7 +169,7 @@ class RegistrationController
         }
     }
 
-    protected function sendVerificationMail($user): void
+    protected function sendVerificationMail(User $user): void
     {
         try {
 
@@ -166,7 +184,7 @@ class RegistrationController
         }
     }
 
-    protected function sendApproveMail($user): void
+    protected function sendApproveMail(User $user): void
     {
         try {
 

--- a/app/system/modules/user/src/Controller/RegistrationController.php
+++ b/app/system/modules/user/src/Controller/RegistrationController.php
@@ -94,8 +94,8 @@ class RegistrationController
 
             // Validate using Symfony Validator (replaces old $user->validate() call)
             // Rule #4: DELETE OVER WRAP - old validate() method has been removed
-            // Use 'registration' validation group to include password validation
-            $this->validateOrFail($user);
+            // Use 'registration' validation group (in addition to Default) to include password validation
+            $this->validateOrFail($user, null, ['Default', 'registration']);
 
             $user->save();
 

--- a/app/system/modules/user/src/Controller/RoleApiController.php
+++ b/app/system/modules/user/src/Controller/RoleApiController.php
@@ -72,12 +72,17 @@ class RoleApiController
             $role = Role::create();
         }
 
-        $role->save($data);
+        // Assign data to entity for validation (without saving yet)
+        foreach ($data as $key => $value) {
+            if (property_exists($role, $key)) {
+                $role->$key = $value;
+            }
+        }
 
         // Validate using Symfony Validator (Step 1.13 - Hybrid Mode)
         $this->validateOrFail($role);
 
-        $role->save();
+        $role->save($data);
 
         return ['message' => 'success', 'role' => $role];
     }

--- a/app/system/modules/user/src/Controller/RoleApiController.php
+++ b/app/system/modules/user/src/Controller/RoleApiController.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\User\Controller;
 
 use Pagekit\Application as App;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\User\Model\Role;
 use function Pagekit\__;
 
 /**
+ * API Controller for Role management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Access("user: manage user permissions")
  */
 class RoleApiController
 {
+    use ValidatesRequestTrait;
+
     /**
      * @Route("/", methods="GET")
      */
@@ -22,33 +31,37 @@ class RoleApiController
     /**
      * @Route("/{id}", methods="GET", requirements={"id"="\d+"})
      */
-    public function getAction($id): Role
+    public function getAction(int $id): Role
     {
         return Role::find($id);
     }
 
     /**
+     * Save a role (create or update).
+     *
+     * Uses Symfony Validator for validation (Step 1.13 - Hybrid Mode).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      */
-    public function saveAction($id = 0, $data = null): array
+    public function saveAction(int $id = 0, ?array $data = null): array
     {
         // Get parameters from request if not provided (Symfony 6.4 compatibility)
         if ($data === null) {
             $request = App::request();
-            
+
             $data = $request->request->all()['role'] ?? [];
             if (empty($data) && $request->getContent()) {
                 $json = json_decode($request->getContent(), true);
                 $data = $json['role'] ?? [];
             }
         }
-        
+
         // Get id from route or data
         if (!$id && isset($data['id'])) {
             $id = (int) $data['id'];
         }
-        
+
         // is new ?
         if (!$role = Role::find($id)) {
 
@@ -61,19 +74,24 @@ class RoleApiController
 
         $role->save($data);
 
+        // Validate using Symfony Validator (Step 1.13 - Hybrid Mode)
+        $this->validateOrFail($role);
+
+        $role->save();
+
         return ['message' => 'success', 'role' => $role];
     }
 
     /**
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      */
-    public function deleteAction($id = 0): array
+    public function deleteAction(int $id = 0): array
     {
         // Get id from route if not provided (Symfony 6.4 compatibility)
         if (!$id) {
             $id = (int) App::request()->get('id', 0);
         }
-        
+
         if ($role = Role::find($id)) {
             $role->delete();
         }
@@ -88,13 +106,13 @@ class RoleApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $roles = $request->request->all()['roles'] ?? [];
         if (empty($roles) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $roles = $json['roles'] ?? [];
         }
-        
+
         foreach ($roles as $data) {
             $id = isset($data['id']) ? $data['id'] : 0;
             $this->saveAction($id, $data);
@@ -110,13 +128,13 @@ class RoleApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);
         }

--- a/app/system/modules/user/src/Controller/UserApiController.php
+++ b/app/system/modules/user/src/Controller/UserApiController.php
@@ -1,18 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\User\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Application\Exception;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\User\Model\Role;
 use Pagekit\User\Model\User;
 use function Pagekit\__;
 
 /**
+ * API Controller for User management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Access("user: manage users")
  */
 class UserApiController
 {
+    use ValidatesRequestTrait;
+
     /**
      * @Route("/", methods="GET")
      */
@@ -23,7 +32,7 @@ class UserApiController
         $filter = $request->query->all()['filter'] ?? [];
         $page = (int) $request->query->get('page', 0);
         $limit = (int) $request->query->get('limit', 0);
-        
+
         $query  = User::query();
         $filter = array_merge(array_fill_keys(['status', 'search', 'role', 'order', 'access'], ''), $filter);
         extract($filter, EXTR_SKIP);
@@ -80,7 +89,7 @@ class UserApiController
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
         $filter = $request->query->all()['filter'] ?? [];
-        
+
         $query  = User::query();
         $filter = array_merge(array_fill_keys(['status', 'search', 'role', 'order', 'access'], ''), (array)$filter);
         extract($filter, EXTR_SKIP);
@@ -124,7 +133,7 @@ class UserApiController
     /**
      * @Route("/{id}", methods="GET", requirements={"id"="\d+"})
      */
-    public function getAction($id): User
+    public function getAction(int $id): User
     {
         if (!$user = User::find($id)) {
             App::abort(404, 'User not found.');
@@ -134,29 +143,33 @@ class UserApiController
     }
 
     /**
+     * Save a user (create or update).
+     *
+     * Uses Symfony Validator for validation (replaces old $user->validate() method).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      */
-    public function saveAction($id = 0)
+    public function saveAction(int $id = 0)
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         // Get user data from POST or JSON body
         $data = $request->request->all()['user'] ?? [];
         $password = $request->request->get('password');
-        
+
         if (empty($data) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $data = $json['user'] ?? [];
             $password = $json['password'] ?? $password;
         }
-        
+
         // Get id from route if not provided
         if (!$id) {
             $id = (int) ($request->request->get('id') ?? $request->get('id', 0));
         }
-        
+
         try {
 
             // is new ?
@@ -209,7 +222,10 @@ class UserApiController
 
             unset($data['login'], $data['registered']);
 
-            $user->validate();
+            // Validate using Symfony Validator (replaces old $user->validate() call)
+            // Rule #4: DELETE OVER WRAP - old validate() method has been removed
+            $this->validateOrFail($user);
+
             $user->save($data);
 
             return ['message' => 'success', 'user' => $user];
@@ -222,13 +238,13 @@ class UserApiController
     /**
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      */
-    public function deleteAction($id = 0): array
+    public function deleteAction(int $id = 0): array
     {
         // Get id from route if not provided (Symfony 6.4 compatibility)
         if (!$id) {
             $id = (int) App::request()->get('id', 0);
         }
-        
+
         if (App::user()->id == $id) {
             App::abort(400, __('Unable to delete yourself.'));
         }
@@ -251,25 +267,25 @@ class UserApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         // Get users data from POST or JSON body
         $users = $request->request->all()['users'] ?? [];
         if (empty($users) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $users = $json['users'] ?? [];
         }
-        
+
         foreach ($users as $data) {
             // Temporarily set the data in request for saveAction
             $id = isset($data['id']) ? $data['id'] : 0;
             $password = $data['password'] ?? null;
-            
+
             // Create a new request with the user data
             $request->request->set('user', $data);
             if ($password) {
                 $request->request->set('password', $password);
             }
-            
+
             $this->saveAction($id);
         }
 
@@ -283,14 +299,14 @@ class UserApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         // Get ids from POST/DELETE body or JSON
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);
         }

--- a/app/system/modules/user/src/Model/Role.php
+++ b/app/system/modules/user/src/Model/Role.php
@@ -43,12 +43,12 @@ class Role implements \JsonSerializable
      * @Column(type="string")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'Role name is required.')]
+    #[Assert\NotBlank(message: 'validation.role.name_required')]
     #[Assert\Length(
         min: 2,
         max: 255,
-        minMessage: 'Role name must be at least {{ limit }} characters.',
-        maxMessage: 'Role name cannot exceed {{ limit }} characters.'
+        minMessage: 'validation.role.name_min_length',
+        maxMessage: 'validation.role.name_max_length'
     )]
     public ?string $name = null;
 
@@ -56,7 +56,7 @@ class Role implements \JsonSerializable
      * @Column(type="integer")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\PositiveOrZero(message: 'Priority must be a non-negative number.')]
+    #[Assert\PositiveOrZero(message: 'validation.role.priority_invalid')]
     public int $priority = 0;
 
     /**

--- a/app/system/modules/user/src/Model/Role.php
+++ b/app/system/modules/user/src/Model/Role.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Pagekit\User\Model;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 /**
+ * Role entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@system_role")
  */
 class Role implements \JsonSerializable
@@ -13,35 +20,49 @@ class Role implements \JsonSerializable
 
     /**
      * The identifier of the anonymous role.
-     *
-     * @var int
      */
-    const ROLE_ANONYMOUS = 1;
+    public const ROLE_ANONYMOUS = 1;
 
     /**
      * The identifier of the authenticated role.
-     *
-     * @var int
      */
-    const ROLE_AUTHENTICATED = 2;
+    public const ROLE_AUTHENTICATED = 2;
 
     /**
      * The identifier of the administrator role.
-     *
-     * @var int
      */
-    const ROLE_ADMINISTRATOR = 3;
+    public const ROLE_ADMINISTRATOR = 3;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'Role name is required.')]
+    #[Assert\Length(
+        min: 2,
+        max: 255,
+        minMessage: 'Role name must be at least {{ limit }} characters.',
+        maxMessage: 'Role name cannot exceed {{ limit }} characters.'
+    )]
     public ?string $name = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\PositiveOrZero(message: 'Priority must be a non-negative number.')]
     public int $priority = 0;
 
-    /** @Column(type="simple_array") */
+    /**
+     * @Column(type="simple_array")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public array $permissions = [];
 
     protected static array $properties = [
@@ -52,7 +73,7 @@ class Role implements \JsonSerializable
     ];
 
     /**
-     * {@inheritdoc}
+     * Check if the role has a specific permission.
      */
     public function hasPermission(string $permission): bool
     {
@@ -60,7 +81,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Add a permission to the role.
      */
     public function addPermission(string $permission): void
     {
@@ -68,7 +89,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Clear all permissions from the role.
      */
     public function clearPermissions(): void
     {
@@ -76,7 +97,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Check if this is a system-locked role.
      */
     public function isLocked(): bool
     {
@@ -84,7 +105,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Check if this is the anonymous role.
      */
     public function isAnonymous(): bool
     {
@@ -92,7 +113,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Check if this is the authenticated role.
      */
     public function isAuthenticated(): bool
     {
@@ -100,7 +121,7 @@ class Role implements \JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * Check if this is the administrator role.
      */
     public function isAdministrator(): bool
     {

--- a/app/system/modules/user/src/Model/User.php
+++ b/app/system/modules/user/src/Model/User.php
@@ -85,10 +85,10 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    // URL is optional. Symfony's Url constraint validates format when provided but accepts null for optional fields.
-    // Empty strings are converted to null via __set() magic method since Url constraint rejects empty strings.
+    // URL is optional. Symfony's Url constraint validates format when provided.
+    // Both null and empty strings are accepted (constraint returns early for empty values).
     #[Assert\Url(message: 'validation.user.url_invalid')]
-    public ?string $url = null;
+    public ?string $url = '';
 
     /**
      * @Column(type="datetime")
@@ -264,25 +264,6 @@ class User implements UserInterface, \JsonSerializable
     // NOTE: The old validate() method has been REMOVED per Rule #4 (DELETE OVER WRAP).
     // All validation is now handled by Symfony Validator attributes on the properties.
     // Controllers must use ValidatesRequestTrait::validate($user) or ValidatesRequestTrait::validateOrFail($user).
-
-    /**
-     * Magic setter to normalize URL field values.
-     *
-     * Converts empty strings to null for the URL field. Symfony's Url constraint accepts null
-     * (optional field) but rejects empty strings. This normalization ensures consistent behavior
-     * when empty strings are assigned from form data or API requests.
-     *
-     * @param string $name Property name
-     * @param mixed $value Property value
-     */
-    public function __set(string $name, mixed $value): void
-    {
-        if ($name === 'url' && $value === '') {
-            $value = null;
-        }
-
-        $this->$name = $value;
-    }
 
     /**
      * {@inheritdoc}

--- a/app/system/modules/user/src/Model/User.php
+++ b/app/system/modules/user/src/Model/User.php
@@ -43,21 +43,21 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'Username is required.')]
+    #[Assert\NotBlank(message: 'validation.user.username_required')]
     #[Assert\Length(
         min: 3,
         max: 255,
-        minMessage: 'Username must be at least {{ limit }} characters.',
-        maxMessage: 'Username cannot exceed {{ limit }} characters.'
+        minMessage: 'validation.user.username_min_length',
+        maxMessage: 'validation.user.username_max_length'
     )]
     #[Assert\Regex(
         pattern: '/^[a-zA-Z0-9._\-]+$/',
-        message: 'Username is invalid. Only letters, numbers, dots, underscores and hyphens are allowed.'
+        message: 'validation.user.username_invalid'
     )]
     #[PagekitAssert\Unique(
         table: '@system_user',
         column: 'username',
-        message: 'Username is not available.'
+        message: 'validation.user.username_not_available'
     )]
     public ?string $username = '';
 
@@ -65,19 +65,19 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'Password is required.', groups: ['registration'])]
+    #[Assert\NotBlank(message: 'validation.user.password_required', groups: ['registration'])]
     public ?string $password = '';
 
     /**
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'Email is required.')]
-    #[Assert\Email(message: 'Email is invalid.')]
+    #[Assert\NotBlank(message: 'validation.user.email_required')]
+    #[Assert\Email(message: 'validation.user.email_invalid')]
     #[PagekitAssert\Unique(
         table: '@system_user',
         column: 'email',
-        message: 'Email is not available.'
+        message: 'validation.user.email_not_available'
     )]
     public ?string $email = '';
 
@@ -85,7 +85,7 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\Url(message: 'URL is invalid.')]
+    #[Assert\Url(message: 'validation.user.url_invalid')]
     public ?string $url = '';
 
     /**
@@ -100,7 +100,7 @@ class User implements UserInterface, \JsonSerializable
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     #[Assert\Choice(
         choices: [self::STATUS_BLOCKED, self::STATUS_ACTIVE],
-        message: 'Invalid status.'
+        message: 'validation.user.status_invalid'
     )]
     public int $status = User::STATUS_ACTIVE;
 
@@ -108,10 +108,10 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'Name is required.')]
+    #[Assert\NotBlank(message: 'validation.user.name_required')]
     #[Assert\Length(
         max: 255,
-        maxMessage: 'Name cannot exceed {{ limit }} characters.'
+        maxMessage: 'validation.user.name_max_length'
     )]
     public ?string $name = null;
 

--- a/app/system/modules/user/src/Model/User.php
+++ b/app/system/modules/user/src/Model/User.php
@@ -85,8 +85,10 @@ class User implements UserInterface, \JsonSerializable
      * @Column
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    // URL is optional. Symfony's Url constraint validates format when provided but accepts null for optional fields.
+    // Empty strings are converted to null via __set() magic method since Url constraint rejects empty strings.
     #[Assert\Url(message: 'validation.user.url_invalid')]
-    public ?string $url = '';
+    public ?string $url = null;
 
     /**
      * @Column(type="datetime")
@@ -262,6 +264,25 @@ class User implements UserInterface, \JsonSerializable
     // NOTE: The old validate() method has been REMOVED per Rule #4 (DELETE OVER WRAP).
     // All validation is now handled by Symfony Validator attributes on the properties.
     // Controllers must use ValidatesRequestTrait::validate($user) or ValidatesRequestTrait::validateOrFail($user).
+
+    /**
+     * Magic setter to normalize URL field values.
+     *
+     * Converts empty strings to null for the URL field. Symfony's Url constraint accepts null
+     * (optional field) but rejects empty strings. This normalization ensures consistent behavior
+     * when empty strings are assigned from form data or API requests.
+     *
+     * @param string $name Property name
+     * @param mixed $value Property value
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        if ($name === 'url' && $value === '') {
+            $value = null;
+        }
+
+        $this->$name = $value;
+    }
 
     /**
      * {@inheritdoc}

--- a/app/system/modules/user/src/Model/User.php
+++ b/app/system/modules/user/src/Model/User.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Pagekit\User\Model;
 
-use Pagekit\Application\Exception;
 use Pagekit\Auth\UserInterface;
 use Pagekit\System\Model\DataModelTrait;
+use Pagekit\System\Validator\Constraints as PagekitAssert;
 use Pagekit\User\Model\AccessModelTrait;
 use Pagekit\User\Model\UserModelTrait;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * User entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@system_user")
  */
 class User implements UserInterface, \JsonSerializable
@@ -19,46 +25,106 @@ class User implements UserInterface, \JsonSerializable
 
     /**
      * The blocked status.
-     *
-     * @var int
      */
-    const STATUS_BLOCKED = 0;
+    public const STATUS_BLOCKED = 0;
 
     /**
      * The active status.
-     *
-     * @var int
      */
-    const STATUS_ACTIVE = 1;
+    public const STATUS_ACTIVE = 1;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'Username is required.')]
+    #[Assert\Length(
+        min: 3,
+        max: 255,
+        minMessage: 'Username must be at least {{ limit }} characters.',
+        maxMessage: 'Username cannot exceed {{ limit }} characters.'
+    )]
+    #[Assert\Regex(
+        pattern: '/^[a-zA-Z0-9._\-]+$/',
+        message: 'Username is invalid. Only letters, numbers, dots, underscores and hyphens are allowed.'
+    )]
+    #[PagekitAssert\Unique(
+        table: '@system_user',
+        column: 'username',
+        message: 'Username is not available.'
+    )]
     public ?string $username = '';
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'Password is required.', groups: ['registration'])]
     public ?string $password = '';
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'Email is required.')]
+    #[Assert\Email(message: 'Email is invalid.')]
+    #[PagekitAssert\Unique(
+        table: '@system_user',
+        column: 'email',
+        message: 'Email is not available.'
+    )]
     public ?string $email = '';
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Url(message: 'URL is invalid.')]
     public ?string $url = '';
 
-    /** @Column(type="datetime") */
+    /**
+     * @Column(type="datetime")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?\DateTime $registered = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Choice(
+        choices: [self::STATUS_BLOCKED, self::STATUS_ACTIVE],
+        message: 'Invalid status.'
+    )]
     public int $status = User::STATUS_ACTIVE;
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'Name is required.')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'Name cannot exceed {{ limit }} characters.'
+    )]
     public ?string $name = null;
 
-    /** @Column(type="datetime") */
+    /**
+     * @Column(type="datetime")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?\DateTime $login = null;
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $activation = null;
 
     protected ?array $permissions = null;
@@ -144,8 +210,6 @@ class User implements UserInterface, \JsonSerializable
 
     /**
      * Check if the user has access for a provided permission identifier
-     *
-     * @param  string  $permission
      */
     public function hasPermission(string $permission): bool
     {
@@ -172,7 +236,6 @@ class User implements UserInterface, \JsonSerializable
      *   - a single permission string can be "create_posts", "create posts", "posts:create" etc.
      *   - a boolean expression with multiple permissions boolean expression can be "create_posts && delete_posts", "(create posts && delete posts) || manage posts" etc.
      *
-     * @param  string $expression
      * @throws \InvalidArgumentException
      */
     public function hasAccess(?string $expression): bool
@@ -196,41 +259,9 @@ class User implements UserInterface, \JsonSerializable
         return (bool) $fn();
     }
 
-    public function validate(): bool
-    {
-        if (empty($this->name)) {
-            throw new Exception(__('Name required.'));
-        }
-
-        if (empty($this->password)) {
-            throw new Exception(__('Password required.'));
-        }
-
-        if (!preg_match('/^[a-zA-Z0-9._\-]{3,}$/', $this->username)) {
-            throw new Exception(__('Username is invalid.'));
-        }
-
-        // TODO: email validation differs from email validation in vuejs
-        if (!filter_var($this->email, FILTER_VALIDATE_EMAIL)) {
-            throw new Exception(__('Email is invalid.'));
-        }
-
-        if (self::where(['id <> :id'], ['id' => $this->id ?: 0])->where(function ($query) {
-            $query->orWhere(['LOWER(username) = :username', 'LOWER(email) = :username'], ['username' => strtolower($this->username)]);
-        })->first()
-        ) {
-            throw new Exception(__('Username not available.'));
-        }
-
-        if (self::where(['id <> :id'], ['id' => $this->id ?: 0])->where(function ($query) {
-            $query->orWhere(['LOWER(username) = :email', 'LOWER(email) = :email'], ['email' => strtolower($this->email)]);
-        })->first()
-        ) {
-            throw new Exception(__('Email not available.'));
-        }
-
-        return true;
-    }
+    // NOTE: The old validate() method has been REMOVED per Rule #4 (DELETE OVER WRAP).
+    // All validation is now handled by Symfony Validator attributes on the properties.
+    // Controllers must use ValidatesRequestTrait::validate($user) or ValidatesRequestTrait::validateOrFail($user).
 
     /**
      * {@inheritdoc}

--- a/app/system/modules/widget/src/Controller/WidgetApiController.php
+++ b/app/system/modules/widget/src/Controller/WidgetApiController.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\Widget\Controller;
 
 use Pagekit\Application as App;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\Widget\Model\Widget;
 use function Pagekit\__;
 
 /**
+ * API Controller for Widget management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Access("system: manage widgets")
  */
 class WidgetApiController
 {
+    use ValidatesRequestTrait;
+
     /**
      * @Route("/", methods="GET")
      */
@@ -38,12 +47,12 @@ class WidgetApiController
     /**
      * @Route("/{id}", methods="GET", requirements={"id"="\d+"})
      */
-    public function getAction($id): Widget
+    public function getAction(int $id): Widget
     {
         if (!$widget = Widget::find($id)) {
             App::abort(404, 'Widget not found.');
         }
-        
+
         // Find and set the widget's position
         $positions = App::position()->all();
         foreach ($positions as $position) {
@@ -63,10 +72,10 @@ class WidgetApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $position = $request->request->get('position', '');
         $ids = $request->request->all()['ids'] ?? [];
-        
+
         if ($request->getContent()) {
             $json = json_decode($request->getContent(), true);
             if ($json) {
@@ -74,49 +83,55 @@ class WidgetApiController
                 $ids = $json['ids'] ?? $ids;
             }
         }
-        
+
         App::position()->assign($position, $ids);
 
         return ['message' => 'success'];
     }
 
     /**
+     * Save a widget (create or update).
+     *
+     * Uses Symfony Validator for validation (replaces manual validation).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      */
-    public function saveAction($id = 0, $data = null): array
+    public function saveAction(int $id = 0, ?array $data = null): array
     {
         // Get parameters from request if not provided (Symfony 6.4 compatibility)
         if ($data === null) {
             $request = App::request();
-            
+
             $data = $request->request->all()['widget'] ?? [];
             if (empty($data) && $request->getContent()) {
                 $json = json_decode($request->getContent(), true);
                 $data = $json['widget'] ?? $json ?? [];
             }
         }
-        
+
         // Get id from route or data
         if (!$id && isset($data['id'])) {
             $id = (int) $data['id'];
         }
-        
+
         if (!$id) {
             $widget = Widget::create();
         } elseif (!$widget = Widget::find($id)) {
             App::abort(404, 'Widget not found.');
         }
 
-        if (empty($data['title'])) {
-            App::abort(400, 'Widget title empty.');
-        }
-        
         // Extract position before saving (it's not a database field)
         $position = isset($data['position']) ? $data['position'] : null;
 
         $widget->save($data);
-        
+
+        // Validate using Symfony Validator (replaces manual title validation)
+        // Rule #4: DELETE OVER WRAP - old manual check removed
+        $this->validateOrFail($widget);
+
+        $widget->save();
+
         // Set position property after save for the event handler
         if ($position !== null) {
             $widget->position = $position;
@@ -128,13 +143,13 @@ class WidgetApiController
     /**
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      */
-    public function deleteAction($id = 0): array
+    public function deleteAction(int $id = 0): array
     {
         // Get id from route if not provided (Symfony 6.4 compatibility)
         if (!$id) {
             $id = (int) App::request()->get('id', 0);
         }
-        
+
         if (!$widget = Widget::find($id)) {
             App::abort(404, 'Widget not found.');
         }
@@ -151,13 +166,13 @@ class WidgetApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach ($ids as $id) {
             if ($widget = Widget::find((int) $id)) {
                 $copy = clone $widget;
@@ -178,13 +193,13 @@ class WidgetApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $widgets = $request->request->all()['widgets'] ?? [];
         if (empty($widgets) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $widgets = $json['widgets'] ?? [];
         }
-        
+
         foreach ($widgets as $data) {
             $id = isset($data['id']) ? $data['id'] : 0;
             $this->saveAction($id, $data);
@@ -200,13 +215,13 @@ class WidgetApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);
         }

--- a/app/system/modules/widget/src/Controller/WidgetApiController.php
+++ b/app/system/modules/widget/src/Controller/WidgetApiController.php
@@ -124,13 +124,18 @@ class WidgetApiController
         // Extract position before saving (it's not a database field)
         $position = isset($data['position']) ? $data['position'] : null;
 
-        $widget->save($data);
+        // Assign data to entity for validation (without saving yet)
+        foreach ($data as $key => $value) {
+            if (property_exists($widget, $key)) {
+                $widget->$key = $value;
+            }
+        }
 
         // Validate using Symfony Validator (replaces manual title validation)
         // Rule #4: DELETE OVER WRAP - old manual check removed
         $this->validateOrFail($widget);
 
-        $widget->save();
+        $widget->save($data);
 
         // Set position property after save for the event handler
         if ($position !== null) {

--- a/app/system/modules/widget/src/Model/Widget.php
+++ b/app/system/modules/widget/src/Model/Widget.php
@@ -7,8 +7,14 @@ namespace Pagekit\Widget\Model;
 use Pagekit\Database\ORM\ModelTrait;
 use Pagekit\System\Model\DataModelTrait;
 use Pagekit\User\Model\AccessModelTrait;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * Widget entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@system_widget")
  */
 #[\AllowDynamicProperties]
@@ -16,18 +22,43 @@ class Widget implements \JsonSerializable
 {
     use AccessModelTrait, DataModelTrait, ModelTrait;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column */
+    /**
+     * @Column
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.widget.title_required')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.widget.title_max_length'
+    )]
     public ?string $title = '';
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.widget.type_required')]
     public ?string $type = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Choice(
+        choices: [0, 1],
+        message: 'validation.widget.status_invalid'
+    )]
     public int $status = 1;
 
-    /** @Column(type="simple_array") */
+    /**
+     * @Column(type="simple_array")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public array $nodes = [];
 }

--- a/app/system/src/Controller/ValidatesRequestTrait.php
+++ b/app/system/src/Controller/ValidatesRequestTrait.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\System\Controller;
+
+use Pagekit\Application as App;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Trait for validating entities using Symfony Validator.
+ *
+ * This trait provides a standardized way to validate entities in controllers
+ * and return consistent JSON error responses for validation failures.
+ *
+ * Usage:
+ * ```php
+ * class MyController
+ * {
+ *     use ValidatesRequestTrait;
+ *
+ *     public function saveAction()
+ *     {
+ *         $entity = new MyEntity();
+ *         // ... populate entity ...
+ *
+ *         if ($errorResponse = $this->validate($entity)) {
+ *             return $errorResponse;
+ *         }
+ *
+ *         // Validation passed, continue with save
+ *     }
+ * }
+ * ```
+ */
+trait ValidatesRequestTrait
+{
+    /**
+     * Validate an entity using Symfony Validator.
+     *
+     * @param object $object The entity to validate
+     * @param ValidatorInterface|null $validator Optional validator instance (uses app container if null)
+     * @param array|null $groups Optional validation groups
+     * @return JsonResponse|null Returns JsonResponse on validation failure, null on success
+     */
+    protected function validate(
+        object $object,
+        ?ValidatorInterface $validator = null,
+        ?array $groups = null
+    ): ?JsonResponse {
+        if ($validator === null) {
+            $validator = App::getInstance()['validator'];
+        }
+
+        $violations = $validator->validate($object, null, $groups);
+
+        if (count($violations) > 0) {
+            return $this->validationErrorResponse($violations);
+        }
+
+        return null; // Validation passed
+    }
+
+    /**
+     * Validate an entity and throw an exception on failure.
+     *
+     * This method is useful when you want to use try/catch error handling
+     * instead of returning JsonResponse directly.
+     *
+     * @param object $object The entity to validate
+     * @param ValidatorInterface|null $validator Optional validator instance
+     * @param array|null $groups Optional validation groups
+     * @throws \Pagekit\Application\Exception When validation fails
+     */
+    protected function validateOrFail(
+        object $object,
+        ?ValidatorInterface $validator = null,
+        ?array $groups = null
+    ): void {
+        if ($validator === null) {
+            $validator = App::getInstance()['validator'];
+        }
+
+        $violations = $validator->validate($object, null, $groups);
+
+        if (count($violations) > 0) {
+            $firstViolation = $violations[0];
+            throw new \Pagekit\Application\Exception($firstViolation->getMessage());
+        }
+    }
+
+    /**
+     * Create a JSON response for validation errors.
+     *
+     * Returns a standardized error format compatible with Vue.js frontend:
+     * {
+     *     "error": true,
+     *     "message": "Validation failed",
+     *     "errors": {
+     *         "propertyName": ["Error message 1", "Error message 2"],
+     *         "anotherProperty": ["Error message"]
+     *     }
+     * }
+     *
+     * @param ConstraintViolationListInterface $violations The validation violations
+     * @return JsonResponse The error response with 400 status code
+     */
+    protected function validationErrorResponse(ConstraintViolationListInterface $violations): JsonResponse
+    {
+        $errors = [];
+
+        foreach ($violations as $violation) {
+            $propertyPath = $violation->getPropertyPath();
+            $message = $violation->getMessage();
+
+            if (!isset($errors[$propertyPath])) {
+                $errors[$propertyPath] = [];
+            }
+
+            $errors[$propertyPath][] = $message;
+        }
+
+        // Get first error message for the main message field
+        $firstError = count($violations) > 0 ? $violations[0]->getMessage() : 'Validation failed';
+
+        return new JsonResponse([
+            'error' => true,
+            'message' => $firstError,
+            'errors' => $errors
+        ], 400);
+    }
+}

--- a/app/system/src/Validator/Constraints/Unique.php
+++ b/app/system/src/Validator/Constraints/Unique.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\System\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint to validate that a value is unique in the database.
+ *
+ * Usage:
+ * ```php
+ * #[Unique(
+ *     table: '@system_user',
+ *     column: 'username',
+ *     message: 'Username is not available.'
+ * )]
+ * public ?string $username = '';
+ * ```
+ *
+ * Note: This constraint uses Pagekit's QueryBuilder (DBAL 3.x compatible).
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+class Unique extends Constraint
+{
+    public string $message = 'This value already exists.';
+    public string $table;
+    public string $column;
+    public ?string $idProperty = 'id';
+
+    /**
+     * @param string $table The database table name (can use @prefix syntax)
+     * @param string $column The column to check for uniqueness
+     * @param string|null $message Custom error message
+     * @param string|null $idProperty The property name that holds the entity ID (for update exclusion)
+     * @param array|null $groups Validation groups
+     * @param mixed $payload Additional payload data
+     */
+    public function __construct(
+        string $table,
+        string $column,
+        ?string $message = null,
+        ?string $idProperty = 'id',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+        $this->table = $table;
+        $this->column = $column;
+        $this->idProperty = $idProperty;
+
+        if ($message !== null) {
+            $this->message = $message;
+        }
+    }
+}

--- a/app/system/src/Validator/Constraints/UniqueValidator.php
+++ b/app/system/src/Validator/Constraints/UniqueValidator.php
@@ -35,12 +35,12 @@ class UniqueValidator extends ConstraintValidator
 
         // Build the uniqueness check query
         // Using Pagekit's QueryBuilder which is DBAL 3.x compatible
-        $queryBuilder = $db->createQueryBuilder();
-        $queryBuilder
+        // Pagekit's QueryBuilder uses where([column => value]) or where(condition, [params])
+        // NOT setParameter() method! Multiple where() calls are AND-ed together
+        $queryBuilder = $db->createQueryBuilder()
             ->select('COUNT(*)')
             ->from($constraint->table)
-            ->where("{$constraint->column} = :value")
-            ->setParameter('value', strtolower((string) $value));
+            ->where([$constraint->column => strtolower((string) $value)]);
 
         // Handle update context: exclude current record by ID
         // Access the object being validated to get its ID
@@ -55,9 +55,7 @@ class UniqueValidator extends ConstraintValidator
 
                 // Only exclude if we have an ID (update scenario)
                 if ($idValue !== null && $idValue > 0) {
-                    $queryBuilder
-                        ->andWhere('id <> :id')
-                        ->setParameter('id', $idValue);
+                    $queryBuilder->where(['id <> :id'], ['id' => $idValue]);
                 }
             }
         }

--- a/app/system/src/Validator/Constraints/UniqueValidator.php
+++ b/app/system/src/Validator/Constraints/UniqueValidator.php
@@ -33,14 +33,13 @@ class UniqueValidator extends ConstraintValidator
         // Get the database connection using Pagekit's Application
         $db = App::db();
 
-        // Build the uniqueness check query
-        // Using Pagekit's QueryBuilder which is DBAL 3.x compatible
-        // Pagekit's QueryBuilder uses where([column => value]) or where(condition, [params])
-        // NOT setParameter() method! Multiple where() calls are AND-ed together
-        $queryBuilder = $db->createQueryBuilder()
-            ->select('COUNT(*)')
-            ->from($constraint->table)
-            ->where([$constraint->column => strtolower((string) $value)]);
+        // Build the uniqueness check query with case-insensitive comparison
+        // Using SQL LOWER() on both column and value for case-insensitive matching
+        // This matches the behavior of the old User::validate() method which used
+        // "LOWER(username) = :username" to prevent case-variant duplicates
+        $lowerValue = strtolower((string) $value);
+        $whereConditions = ["LOWER({$constraint->column}) = :value"];
+        $whereParams = ['value' => $lowerValue];
 
         // Handle update context: exclude current record by ID
         // Access the object being validated to get its ID
@@ -55,10 +54,17 @@ class UniqueValidator extends ConstraintValidator
 
                 // Only exclude if we have an ID (update scenario)
                 if ($idValue !== null && $idValue > 0) {
-                    $queryBuilder->where(['id <> :id'], ['id' => $idValue]);
+                    $whereConditions[] = "id <> :id";
+                    $whereParams['id'] = $idValue;
                 }
             }
         }
+
+        // Build query with all conditions combined
+        $queryBuilder = $db->createQueryBuilder()
+            ->select('COUNT(*)')
+            ->from($constraint->table)
+            ->where($whereConditions, $whereParams);
 
         // Execute query and get count
         // DBAL 3.x: execute() returns Result, fetchOne() gets single value

--- a/app/system/src/Validator/Constraints/UniqueValidator.php
+++ b/app/system/src/Validator/Constraints/UniqueValidator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\System\Validator\Constraints;
+
+use Pagekit\Application as App;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validator for the Unique constraint.
+ *
+ * Checks if a value already exists in the database, excluding the current
+ * entity when updating (based on ID).
+ *
+ * Uses Pagekit's static DB access since DI is not yet fully modernized for Validators.
+ */
+class UniqueValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Unique) {
+            throw new UnexpectedTypeException($constraint, Unique::class);
+        }
+
+        // Skip validation for null or empty values (let NotBlank handle that)
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        // Get the database connection using Pagekit's Application
+        $db = App::db();
+
+        // Build the uniqueness check query
+        // Using Pagekit's QueryBuilder which is DBAL 3.x compatible
+        $queryBuilder = $db->createQueryBuilder();
+        $queryBuilder
+            ->select('COUNT(*)')
+            ->from($constraint->table)
+            ->where("{$constraint->column} = :value")
+            ->setParameter('value', strtolower((string) $value));
+
+        // Handle update context: exclude current record by ID
+        // Access the object being validated to get its ID
+        $object = $this->context->getObject();
+
+        if ($object !== null && $constraint->idProperty !== null) {
+            $idProperty = $constraint->idProperty;
+
+            // Get the ID value using property access
+            if (property_exists($object, $idProperty)) {
+                $idValue = $object->$idProperty;
+
+                // Only exclude if we have an ID (update scenario)
+                if ($idValue !== null && $idValue > 0) {
+                    $queryBuilder
+                        ->andWhere('id <> :id')
+                        ->setParameter('id', $idValue);
+                }
+            }
+        }
+
+        // Execute query and get count
+        // DBAL 3.x: execute() returns Result, fetchOne() gets single value
+        $result = $queryBuilder->execute();
+        $count = (int) $result->fetchOne();
+
+        if ($count > 0) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', (string) $value)
+                ->addViolation();
+        }
+    }
+}

--- a/app/system/src/ValidatorServiceProvider.php
+++ b/app/system/src/ValidatorServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\System;
+
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Service provider for Symfony Validator integration.
+ *
+ * This provider sets up the Symfony Validator with PHP 8 Attribute support.
+ * Part of the hybrid validation strategy (Step 1.13):
+ * - Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * - ORM: Still uses Doctrine Annotations (until Step 1.14)
+ *
+ * @see https://symfony.com/doc/current/validation.html
+ */
+class ValidatorServiceProvider
+{
+    /**
+     * Register the Symfony Validator service.
+     *
+     * @param \Pagekit\Application $app The Pagekit application container
+     */
+    public static function register($app): void
+    {
+        $app['validator'] = function ($app): ValidatorInterface {
+            $builder = Validation::createValidatorBuilder();
+
+            // CRITICAL: Enable PHP 8 Attribute support for Validation
+            // This allows using #[Assert\NotBlank], #[Assert\Email], etc.
+            $builder->enableAttributeMapping();
+
+            // Register custom constraint validators
+            // The UniqueValidator will be auto-discovered by Symfony's naming convention
+            // (Constraint class + "Validator" suffix in the same namespace)
+
+            return $builder->getValidator();
+        };
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     "symfony/twig-bridge": "^6.4",
     "symfony/yaml": "^6.4",
     "symfony/cache": "^6.4",
-    "doctrine/migrations": "^3.9"
+    "doctrine/migrations": "^3.9",
+    "symfony/validator": "^7.4"
   },
   "require-dev": {
     "ext-dom": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pagekit/pagekit",
   "title": "Pagekit",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "type": "project",
   "description": "The Pagekit CMS",
   "keywords": [

--- a/migration-docs/branches/VALIDATION_PHASE2_DISCOVERY.md
+++ b/migration-docs/branches/VALIDATION_PHASE2_DISCOVERY.md
@@ -1,0 +1,135 @@
+# Symfony Validator Migration - Phase 2 Discovery
+
+## Overview
+
+This document lists all entities and controllers that need to be migrated to use Symfony Validator in Phase 2.
+
+## Discovered Entities Requiring Validation
+
+### Already Migrated (Phase 1)
+
+| Entity | Location | Status |
+|--------|----------|--------|
+| `User` | `app/system/modules/user/src/Model/User.php` | ✅ DONE |
+| `Role` | `app/system/modules/user/src/Model/Role.php` | ✅ DONE |
+
+### To Be Migrated (Phase 2)
+
+| Entity | Location | Priority | Validation Needed |
+|--------|----------|----------|-------------------|
+| `Node` | `app/system/modules/site/src/Model/Node.php` | HIGH | slug, title, link, status |
+| `Page` | `app/system/modules/site/src/Model/Page.php` | MEDIUM | title |
+| `Widget` | `app/system/modules/widget/src/Model/Widget.php` | HIGH | title, type, status |
+
+## Controllers with Manual Validation
+
+### Already Migrated (Phase 1)
+
+| Controller | Location | Status |
+|------------|----------|--------|
+| `UserApiController` | `app/system/modules/user/src/Controller/` | ✅ DONE |
+| `RegistrationController` | `app/system/modules/user/src/Controller/` | ✅ DONE |
+| `ProfileController` | `app/system/modules/user/src/Controller/` | ✅ DONE |
+
+### To Be Migrated (Phase 2)
+
+| Controller | Location | Manual Validation Found |
+|------------|----------|------------------------|
+| `NodeApiController` | `app/system/modules/site/src/Controller/` | `App::abort(400, 'Invalid slug')`, `App::abort(400, 'Link is required')` |
+| `WidgetApiController` | `app/system/modules/widget/src/Controller/` | `App::abort(400, 'Widget title empty')` |
+| `MenuApiController` | `app/system/modules/site/src/Controller/` | `App::abort(400, 'Invalid id')` - Business logic, not entity validation |
+| `RoleApiController` | `app/system/modules/user/src/Controller/` | No manual validation, but should use `ValidatesRequestTrait` for Role entity |
+
+## Hardcoded Validation Messages Found
+
+### Site Module - NodeApiController
+
+```php
+// Line 76
+App::abort(400, __('Invalid slug.'));
+
+// Line 82
+App::abort(400, __('Link is required. Please specify a valid URL or route.'));
+
+// Line 103
+App::abort(400, __('Invalid type.')); // Business logic, not entity validation
+
+// Line 211
+App::abort(400, __('Invalid node type.')); // Business logic, not entity validation
+```
+
+### Widget Module - WidgetApiController
+
+```php
+// Line 112
+App::abort(400, 'Widget title empty.'); // Note: Not using __() function!
+```
+
+### Site Module - MenuApiController
+
+```php
+// Line 61
+App::abort(400, __('Invalid id.')); // Business logic for menu slugification
+```
+
+## Migration Priority Order
+
+1. **Widget Module** (Simple, single entity)
+   - Entity: `Widget.php`
+   - Controller: `WidgetApiController.php`
+   
+2. **Site Module** (More complex, 2 entities)
+   - Entity: `Node.php`, `Page.php`
+   - Controller: `NodeApiController.php`
+   
+3. **User Module - RoleApiController** (Add ValidatesRequestTrait)
+   - Controller: `RoleApiController.php`
+
+## Validation Rules to Implement
+
+### Node Entity
+
+| Property | Constraints | Message Key |
+|----------|-------------|-------------|
+| `slug` | NotBlank, Regex(/^[a-z0-9\-_]+$/) | `validation.node.slug_required`, `validation.node.slug_invalid` |
+| `title` | NotBlank, Length(max: 255) | `validation.node.title_required`, `validation.node.title_max_length` |
+| `link` | Length(max: 500) | `validation.node.link_max_length` |
+| `type` | NotBlank | `validation.node.type_required` |
+| `status` | Choice(0, 1) | `validation.node.status_invalid` |
+
+### Page Entity
+
+| Property | Constraints | Message Key |
+|----------|-------------|-------------|
+| `title` | NotBlank, Length(max: 255) | `validation.page.title_required`, `validation.page.title_max_length` |
+
+### Widget Entity
+
+| Property | Constraints | Message Key |
+|----------|-------------|-------------|
+| `title` | NotBlank, Length(max: 255) | `validation.widget.title_required`, `validation.widget.title_max_length` |
+| `type` | NotBlank | `validation.widget.type_required` |
+| `status` | Choice(0, 1) | `validation.widget.status_invalid` |
+
+## Notes
+
+### Business Logic vs Entity Validation
+
+Some validation in controllers is **business logic**, not entity validation:
+
+1. **MenuApiController** - `Invalid id` check is for slugification, not entity validation
+2. **NodeApiController** - `Invalid type` and `Invalid node type` are checking if the node type is protected or not allowed as frontpage
+
+These should **remain in controllers** as they involve business rules, not simple field validation.
+
+### ORM Annotations
+
+All ORM annotations (`@Entity`, `@Column`, `@Id`) must be preserved and marked with:
+
+```php
+// TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+```
+
+### Translation Integration
+
+Message keys will be stored in `app/system/languages/en_US/validation.php`. Actual translation integration (using `__()` function or Symfony Translator) will be handled in a later phase.

--- a/migration-docs/branches/VALIDATION_SYSTEM.md
+++ b/migration-docs/branches/VALIDATION_SYSTEM.md
@@ -1,0 +1,353 @@
+# Symfony Validator Integration (Step 1.13 - Hybrid Mode)
+
+## Overview
+
+This document describes the integration of Symfony Validator 7.4 with PHP 8 Attributes support into the Pagekit CMS. The implementation follows a **hybrid approach**:
+
+- **Validation**: Uses PHP 8 Attributes (`#[Assert\...]`)
+- **ORM**: Still uses Doctrine Annotations (`@Entity`, `@Column`) - Will be migrated in Step 1.14
+
+## Changes Made
+
+### 1. Dependencies Added
+
+```json
+{
+  "require": {
+    "symfony/validator": "^7.4"
+  }
+}
+```
+
+### 2. New Files Created
+
+#### ValidatorServiceProvider
+`app/system/src/ValidatorServiceProvider.php`
+
+Registers the Symfony Validator as a service in the Pagekit application container:
+
+```php
+$app['validator'] = function ($app): ValidatorInterface {
+    $builder = Validation::createValidatorBuilder();
+    $builder->enableAttributeMapping();
+    return $builder->getValidator();
+};
+```
+
+#### ValidatesRequestTrait
+`app/system/src/Controller/ValidatesRequestTrait.php`
+
+Provides standardized validation methods for controllers:
+
+- `validate($object)`: Returns `JsonResponse` on failure, `null` on success
+- `validateOrFail($object)`: Throws `Exception` on failure
+- `validationErrorResponse($violations)`: Creates structured JSON error response
+
+#### Custom Constraints
+`app/system/src/Validator/Constraints/`
+
+- `Unique.php`: Attribute-based constraint for database uniqueness checks
+- `UniqueValidator.php`: Validator implementation using Pagekit's QueryBuilder (DBAL 3.x)
+
+### 3. Modified Files
+
+#### User Entity
+`app/system/modules/user/src/Model/User.php`
+
+**BEFORE** (Manual validation):
+```php
+public function validate(): bool
+{
+    if (empty($this->name)) {
+        throw new Exception(__('Name required.'));
+    }
+    // ... more manual checks ...
+}
+```
+
+**AFTER** (Symfony Validator Attributes):
+```php
+#[Assert\NotBlank(message: 'Name is required.')]
+#[Assert\Length(max: 255)]
+public ?string $name = null;
+
+#[Assert\NotBlank(message: 'Username is required.')]
+#[Assert\Length(min: 3, max: 255)]
+#[Assert\Regex(pattern: '/^[a-zA-Z0-9._\-]+$/')]
+#[PagekitAssert\Unique(table: '@system_user', column: 'username')]
+public ?string $username = '';
+
+#[Assert\NotBlank(message: 'Email is required.')]
+#[Assert\Email(message: 'Email is invalid.')]
+#[PagekitAssert\Unique(table: '@system_user', column: 'email')]
+public ?string $email = '';
+```
+
+**NOTE**: The old `validate()` method was **REMOVED** per Rule #4 (DELETE OVER WRAP).
+
+#### Role Entity
+`app/system/modules/user/src/Model/Role.php`
+
+Added validation attributes:
+- `name`: `#[Assert\NotBlank]`, `#[Assert\Length(min: 2, max: 255)]`
+- `priority`: `#[Assert\PositiveOrZero]`
+
+#### Controllers Updated
+
+All controllers now use `ValidatesRequestTrait`:
+
+1. **UserApiController** (`app/system/modules/user/src/Controller/UserApiController.php`)
+   - Added `use ValidatesRequestTrait;`
+   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
+   - Added `declare(strict_types=1)`
+
+2. **RegistrationController** (`app/system/modules/user/src/Controller/RegistrationController.php`)
+   - Added `use ValidatesRequestTrait;`
+   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
+   - Added `declare(strict_types=1)`
+
+3. **ProfileController** (`app/system/modules/user/src/Controller/ProfileController.php`)
+   - Added `use ValidatesRequestTrait;`
+   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
+   - Added `declare(strict_types=1)`
+
+### 4. Service Registration
+
+The validator service is registered in `app/system/index.php` during the `boot` event:
+
+```php
+'boot' => function ($event, $app) {
+    \Pagekit\System\ValidatorServiceProvider::register($app);
+    // ...
+}
+```
+
+## Validation Constraints Used
+
+### Symfony Built-in Constraints
+
+| Constraint | Used On | Purpose |
+|------------|---------|---------|
+| `#[Assert\NotBlank]` | User.username, User.email, User.name, User.password, Role.name | Required field validation |
+| `#[Assert\Email]` | User.email | Email format validation |
+| `#[Assert\Length]` | User.username, User.name, Role.name | Min/max length validation |
+| `#[Assert\Regex]` | User.username | Pattern validation |
+| `#[Assert\Url]` | User.url | URL format validation |
+| `#[Assert\Choice]` | User.status | Enum validation |
+| `#[Assert\PositiveOrZero]` | Role.priority | Numeric validation |
+
+### Custom Constraints
+
+| Constraint | Used On | Purpose |
+|------------|---------|---------|
+| `#[PagekitAssert\Unique]` | User.username, User.email | Database uniqueness check |
+
+## Validation Groups
+
+The `registration` validation group is used for password validation during user registration:
+
+```php
+#[Assert\NotBlank(message: 'Password is required.', groups: ['registration'])]
+public ?string $password = '';
+```
+
+## Error Response Format
+
+Validation errors are returned as JSON with the following structure:
+
+```json
+{
+  "error": true,
+  "message": "First error message for display",
+  "errors": {
+    "username": ["Username is required.", "Username must be at least 3 characters."],
+    "email": ["Email is invalid."]
+  }
+}
+```
+
+HTTP Status Code: **400 Bad Request**
+
+## Usage Guide
+
+### In Controllers
+
+```php
+use Pagekit\System\Controller\ValidatesRequestTrait;
+
+class MyController
+{
+    use ValidatesRequestTrait;
+
+    public function saveAction()
+    {
+        $entity = new MyEntity();
+        // ... populate entity ...
+
+        // Option 1: Return JSON response on failure
+        if ($errorResponse = $this->validate($entity)) {
+            return $errorResponse;
+        }
+
+        // Option 2: Throw exception on failure (for try/catch handling)
+        $this->validateOrFail($entity);
+
+        // Validation passed, continue with save
+        $entity->save();
+    }
+}
+```
+
+### Adding Validation to New Entities
+
+1. Import the Symfony Validator constraints:
+   ```php
+   use Symfony\Component\Validator\Constraints as Assert;
+   use Pagekit\System\Validator\Constraints as PagekitAssert;
+   ```
+
+2. Add attributes to properties:
+   ```php
+   #[Assert\NotBlank(message: 'Field is required.')]
+   #[Assert\Length(min: 3, max: 100)]
+   public ?string $myField = '';
+   ```
+
+3. For database uniqueness:
+   ```php
+   #[PagekitAssert\Unique(
+       table: '@my_table',
+       column: 'my_column',
+       message: 'Value already exists.'
+   )]
+   public ?string $uniqueField = '';
+   ```
+
+## Hybrid Mode Notes
+
+### Why Hybrid?
+
+The ORM still uses Doctrine Annotations (`doctrine/annotations` package) because:
+- Step 1.14 (ORM Attributes Migration) is pending
+- Entity mapping relies on `@Entity`, `@Column`, `@Id` annotations
+- Both can coexist on the same class
+
+### ORM Annotations (Temporary)
+
+All ORM annotations are marked with TODO comments:
+
+```php
+/** @Column */
+// TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+```
+
+### When Step 1.14 is Complete
+
+After ORM Attributes migration:
+1. Replace `@Entity`, `@Column`, `@Id` annotations with `#[ORM\Entity]`, `#[ORM\Column]`, `#[ORM\Id]`
+2. Remove `// TODO: Must be refactored in Step 1.14` comments
+3. Update `doctrine/annotations` usage
+
+## Migration from Manual Validation
+
+### Old Pattern (REMOVED)
+
+```php
+// In Entity
+public function validate(): bool
+{
+    if (empty($this->name)) {
+        throw new Exception(__('Name required.'));
+    }
+    return true;
+}
+
+// In Controller
+$user->validate();
+$user->save();
+```
+
+### New Pattern (CURRENT)
+
+```php
+// In Entity - just attributes, no validate() method
+#[Assert\NotBlank(message: 'Name is required.')]
+public ?string $name = null;
+
+// In Controller
+use ValidatesRequestTrait;
+// ...
+$this->validateOrFail($user);
+$user->save();
+```
+
+## Aggressive Modernization Rules Applied
+
+| Rule | Application |
+|------|-------------|
+| **#1 NO COMPATIBILITY LAYERS** | No shim classes created; all controllers updated directly |
+| **#2 NO ADAPTERS** | All `$user->validate()` calls replaced in the same commit |
+| **#3 BREAKING CHANGES ALLOWED** | Internal API changed (validate() method removed) |
+| **#4 DELETE OVER WRAP** | Old `validate()` method completely removed, not wrapped |
+| **#5 MANDATORY FLAGGING** | All ORM annotations marked with `// TODO: Must be refactored in Step 1.14` |
+
+## Files Changed
+
+```
+Modified:
+- composer.json (added symfony/validator)
+- app/system/index.php (registered validator service)
+- app/system/modules/user/src/Model/User.php (added validation attributes, removed validate())
+- app/system/modules/user/src/Model/Role.php (added validation attributes)
+- app/system/modules/user/src/Controller/UserApiController.php (use ValidatesRequestTrait)
+- app/system/modules/user/src/Controller/RegistrationController.php (use ValidatesRequestTrait)
+- app/system/modules/user/src/Controller/ProfileController.php (use ValidatesRequestTrait)
+
+Created:
+- app/system/src/ValidatorServiceProvider.php
+- app/system/src/Controller/ValidatesRequestTrait.php
+- app/system/src/Validator/Constraints/Unique.php
+- app/system/src/Validator/Constraints/UniqueValidator.php
+- migration-docs/branches/VALIDATION_SYSTEM.md (this file)
+```
+
+## Testing
+
+### Manual Tests
+
+1. **Page Load Test**: Access `/admin` - should redirect to login
+2. **Invalid Data Test**: Submit registration with empty fields - should return validation errors
+3. **Valid Data Test**: Submit valid registration - should succeed
+4. **ORM Test**: Load users via `User::find(1)` - should work correctly
+
+### Automated Tests
+
+TODO: Add unit tests for:
+- `ValidatorServiceProvider` registration
+- `ValidatesRequestTrait` methods
+- `Unique` constraint validator
+- User entity validation
+
+## Rollback Plan
+
+If issues occur:
+
+1. Revert the branch
+2. Remove `symfony/validator` from `composer.json`
+3. Run `composer update`
+4. Verify system works
+
+## Next Steps
+
+1. **Step 1.14**: Migrate ORM from Annotations to Attributes
+   - Replace `@Entity` with `#[ORM\Entity]`
+   - Replace `@Column` with `#[ORM\Column]`
+   - Remove `doctrine/annotations` dependency
+   - Remove TODO comments
+
+2. Add validation to other entities as needed
+
+3. Consider adding more custom constraints:
+   - `#[UniqueEmail]` - Email uniqueness across multiple tables
+   - `#[StrongPassword]` - Password strength validation
+   - `#[ValidSlug]` - URL slug validation

--- a/migration-docs/branches/VALIDATION_SYSTEM.md
+++ b/migration-docs/branches/VALIDATION_SYSTEM.md
@@ -23,6 +23,11 @@ This document describes the integration of Symfony Validator 7.4 with PHP 8 Attr
 - Widget module migrated (Widget entity and controller)
 - User module messages updated to use message keys
 
+### Phase 3 (Completed)
+- Comment base module migrated (abstract Comment class)
+- Blog package migrated (Post, Comment entities and controllers)
+- All extension packages now use Symfony Validator
+
 ---
 
 ## 1. Dependencies
@@ -112,6 +117,21 @@ public ?string $username = '';
 **Controllers:**
 - `WidgetApiController.php` - Uses ValidatesRequestTrait
 
+### Comment Module - Base (Phase 3)
+
+**Entities:**
+- `Comment.php` (abstract) - Author, content, status validation
+
+### Blog Package (Phase 3)
+
+**Entities:**
+- `Post.php` - Title, slug, status, user_id validation
+- `Comment.php` - Email, url, post_id validation (extends base Comment)
+
+**Controllers:**
+- `PostApiController.php` - Uses ValidatesRequestTrait
+- `CommentApiController.php` - Uses ValidatesRequestTrait
+
 ---
 
 ## 4. Validation Constraints Reference
@@ -120,13 +140,14 @@ public ?string $username = '';
 
 | Constraint | Used On | Purpose |
 |------------|---------|---------|
-| `#[Assert\NotBlank]` | User.username, User.email, User.name, User.password, Role.name, Node.slug, Node.title, Node.type, Page.title, Widget.title, Widget.type | Required field validation |
-| `#[Assert\Email]` | User.email | Email format validation |
-| `#[Assert\Length]` | User.username, User.name, Role.name, Node.slug, Node.title, Node.link, Page.title, Widget.title | Min/max length validation |
-| `#[Assert\Regex]` | User.username, Node.slug | Pattern validation |
-| `#[Assert\Url]` | User.url | URL format validation |
-| `#[Assert\Choice]` | User.status, Node.status, Widget.status | Enum validation |
-| `#[Assert\PositiveOrZero]` | Role.priority, Node.priority, Node.parent_id | Numeric validation |
+| `#[Assert\NotBlank]` | User.username, User.email, User.name, User.password, Role.name, Node.slug, Node.title, Node.type, Page.title, Widget.title, Widget.type, Comment.author, Comment.content, Post.title, Post.slug, Post.user_id, BlogComment.post_id | Required field validation |
+| `#[Assert\Email]` | User.email, BlogComment.email | Email format validation |
+| `#[Assert\Length]` | User.username, User.name, Role.name, Node.slug, Node.title, Node.link, Page.title, Widget.title, Comment.author, Post.title, Post.slug | Min/max length validation |
+| `#[Assert\Regex]` | User.username, Node.slug, Post.slug | Pattern validation |
+| `#[Assert\Url]` | User.url, BlogComment.url | URL format validation |
+| `#[Assert\Choice]` | User.status, Node.status, Widget.status, Comment.status, Post.status | Enum validation |
+| `#[Assert\PositiveOrZero]` | Role.priority, Node.priority, Node.parent_id, Post.comment_count | Numeric validation |
+| `#[Assert\Positive]` | Post.user_id, BlogComment.post_id | Positive integer validation |
 
 ### Custom Constraints
 

--- a/migration-docs/branches/VALIDATION_SYSTEM.md
+++ b/migration-docs/branches/VALIDATION_SYSTEM.md
@@ -7,9 +7,25 @@ This document describes the integration of Symfony Validator 7.4 with PHP 8 Attr
 - **Validation**: Uses PHP 8 Attributes (`#[Assert\...]`)
 - **ORM**: Still uses Doctrine Annotations (`@Entity`, `@Column`) - Will be migrated in Step 1.14
 
-## Changes Made
+## Migration Phases
 
-### 1. Dependencies Added
+### Phase 1 (Completed)
+- Symfony Validator 7.4 installed and configured
+- `ValidatorServiceProvider` created and registered
+- `ValidatesRequestTrait` created for controller validation
+- Custom `Unique` constraint implemented
+- User module fully migrated (User, Role entities and controllers)
+
+### Phase 2 (Completed)
+- Validation messages file created (`app/system/languages/en_US/validation.php`)
+- All hardcoded messages replaced with message keys
+- Site module migrated (Node, Page entities and controllers)
+- Widget module migrated (Widget entity and controller)
+- User module messages updated to use message keys
+
+---
+
+## 1. Dependencies
 
 ```json
 {
@@ -19,9 +35,9 @@ This document describes the integration of Symfony Validator 7.4 with PHP 8 Attr
 }
 ```
 
-### 2. New Files Created
+## 2. Infrastructure Files
 
-#### ValidatorServiceProvider
+### ValidatorServiceProvider
 `app/system/src/ValidatorServiceProvider.php`
 
 Registers the Symfony Validator as a service in the Pagekit application container:
@@ -34,7 +50,7 @@ $app['validator'] = function ($app): ValidatorInterface {
 };
 ```
 
-#### ValidatesRequestTrait
+### ValidatesRequestTrait
 `app/system/src/Controller/ValidatesRequestTrait.php`
 
 Provides standardized validation methods for controllers:
@@ -43,98 +59,74 @@ Provides standardized validation methods for controllers:
 - `validateOrFail($object)`: Throws `Exception` on failure
 - `validationErrorResponse($violations)`: Creates structured JSON error response
 
-#### Custom Constraints
+### Custom Constraints
 `app/system/src/Validator/Constraints/`
 
 - `Unique.php`: Attribute-based constraint for database uniqueness checks
 - `UniqueValidator.php`: Validator implementation using Pagekit's QueryBuilder (DBAL 3.x)
 
-### 3. Modified Files
+### Validation Messages File
+`app/system/languages/en_US/validation.php`
 
-#### User Entity
-`app/system/modules/user/src/Model/User.php`
+Centralized validation messages for all entities. Messages are referenced by key in entity attributes:
 
-**BEFORE** (Manual validation):
 ```php
-public function validate(): bool
-{
-    if (empty($this->name)) {
-        throw new Exception(__('Name required.'));
-    }
-    // ... more manual checks ...
-}
-```
+// In validation.php
+'validation.user.username_required' => 'Username is required.',
 
-**AFTER** (Symfony Validator Attributes):
-```php
-#[Assert\NotBlank(message: 'Name is required.')]
-#[Assert\Length(max: 255)]
-public ?string $name = null;
-
-#[Assert\NotBlank(message: 'Username is required.')]
-#[Assert\Length(min: 3, max: 255)]
-#[Assert\Regex(pattern: '/^[a-zA-Z0-9._\-]+$/')]
-#[PagekitAssert\Unique(table: '@system_user', column: 'username')]
+// In entity
+#[Assert\NotBlank(message: 'validation.user.username_required')]
 public ?string $username = '';
-
-#[Assert\NotBlank(message: 'Email is required.')]
-#[Assert\Email(message: 'Email is invalid.')]
-#[PagekitAssert\Unique(table: '@system_user', column: 'email')]
-public ?string $email = '';
 ```
 
-**NOTE**: The old `validate()` method was **REMOVED** per Rule #4 (DELETE OVER WRAP).
+---
 
-#### Role Entity
-`app/system/modules/user/src/Model/Role.php`
+## 3. Migrated Modules
 
-Added validation attributes:
-- `name`: `#[Assert\NotBlank]`, `#[Assert\Length(min: 2, max: 255)]`
-- `priority`: `#[Assert\PositiveOrZero]`
+### User Module (Phase 1 + 2)
 
-#### Controllers Updated
+**Entities:**
+- `User.php` - Full validation with Unique constraints
+- `Role.php` - Name and priority validation
 
-All controllers now use `ValidatesRequestTrait`:
+**Controllers:**
+- `UserApiController.php` - Uses ValidatesRequestTrait
+- `RegistrationController.php` - Uses ValidatesRequestTrait
+- `ProfileController.php` - Uses ValidatesRequestTrait
+- `RoleApiController.php` - Uses ValidatesRequestTrait (Phase 2)
 
-1. **UserApiController** (`app/system/modules/user/src/Controller/UserApiController.php`)
-   - Added `use ValidatesRequestTrait;`
-   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
-   - Added `declare(strict_types=1)`
+### Site Module (Phase 2)
 
-2. **RegistrationController** (`app/system/modules/user/src/Controller/RegistrationController.php`)
-   - Added `use ValidatesRequestTrait;`
-   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
-   - Added `declare(strict_types=1)`
+**Entities:**
+- `Node.php` - Slug, title, link, type, status validation
+- `Page.php` - Title validation
 
-3. **ProfileController** (`app/system/modules/user/src/Controller/ProfileController.php`)
-   - Added `use ValidatesRequestTrait;`
-   - Replaced `$user->validate()` with `$this->validateOrFail($user)`
-   - Added `declare(strict_types=1)`
+**Controllers:**
+- `NodeApiController.php` - Uses ValidatesRequestTrait
 
-### 4. Service Registration
+### Widget Module (Phase 2)
 
-The validator service is registered in `app/system/index.php` during the `boot` event:
+**Entities:**
+- `Widget.php` - Title, type, status validation
 
-```php
-'boot' => function ($event, $app) {
-    \Pagekit\System\ValidatorServiceProvider::register($app);
-    // ...
-}
-```
+**Controllers:**
+- `WidgetApiController.php` - Uses ValidatesRequestTrait
 
-## Validation Constraints Used
+---
+
+## 4. Validation Constraints Reference
 
 ### Symfony Built-in Constraints
 
 | Constraint | Used On | Purpose |
 |------------|---------|---------|
-| `#[Assert\NotBlank]` | User.username, User.email, User.name, User.password, Role.name | Required field validation |
+| `#[Assert\NotBlank]` | User.username, User.email, User.name, User.password, Role.name, Node.slug, Node.title, Node.type, Page.title, Widget.title, Widget.type | Required field validation |
 | `#[Assert\Email]` | User.email | Email format validation |
-| `#[Assert\Length]` | User.username, User.name, Role.name | Min/max length validation |
-| `#[Assert\Regex]` | User.username | Pattern validation |
+| `#[Assert\Length]` | User.username, User.name, Role.name, Node.slug, Node.title, Node.link, Page.title, Widget.title | Min/max length validation |
+| `#[Assert\Regex]` | User.username, Node.slug | Pattern validation |
 | `#[Assert\Url]` | User.url | URL format validation |
-| `#[Assert\Choice]` | User.status | Enum validation |
-| `#[Assert\PositiveOrZero]` | Role.priority | Numeric validation |
+| `#[Assert\Choice]` | User.status, Node.status, Widget.status | Enum validation |
+| `#[Assert\PositiveOrZero]` | Role.priority, Node.priority, Node.parent_id | Numeric validation |
 
 ### Custom Constraints
 
@@ -142,33 +134,49 @@ The validator service is registered in `app/system/index.php` during the `boot` 
 |------------|---------|---------|
 | `#[PagekitAssert\Unique]` | User.username, User.email | Database uniqueness check |
 
-## Validation Groups
+---
 
-The `registration` validation group is used for password validation during user registration:
+## 5. Message Keys Reference
 
-```php
-#[Assert\NotBlank(message: 'Password is required.', groups: ['registration'])]
-public ?string $password = '';
-```
+All validation messages are stored in `app/system/languages/en_US/validation.php`.
 
-## Error Response Format
+### User Module Messages
 
-Validation errors are returned as JSON with the following structure:
+| Key | Message |
+|-----|---------|
+| `validation.user.username_required` | Username is required. |
+| `validation.user.username_min_length` | Username must be at least {{ limit }} characters. |
+| `validation.user.username_max_length` | Username cannot exceed {{ limit }} characters. |
+| `validation.user.username_invalid` | Username is invalid. Only letters, numbers, dots, underscores and hyphens are allowed. |
+| `validation.user.username_not_available` | Username is not available. |
+| `validation.user.email_required` | Email is required. |
+| `validation.user.email_invalid` | Email is invalid. |
+| `validation.user.email_not_available` | Email is not available. |
+| `validation.user.name_required` | Name is required. |
+| `validation.user.password_required` | Password is required. |
+| `validation.role.name_required` | Role name is required. |
+| `validation.role.priority_invalid` | Priority must be a non-negative number. |
 
-```json
-{
-  "error": true,
-  "message": "First error message for display",
-  "errors": {
-    "username": ["Username is required.", "Username must be at least 3 characters."],
-    "email": ["Email is invalid."]
-  }
-}
-```
+### Site Module Messages
 
-HTTP Status Code: **400 Bad Request**
+| Key | Message |
+|-----|---------|
+| `validation.node.slug_required` | Slug is required. |
+| `validation.node.slug_invalid` | Invalid slug. Only lowercase letters, numbers, hyphens and underscores are allowed. |
+| `validation.node.title_required` | Title is required. |
+| `validation.node.type_required` | Node type is required. |
+| `validation.page.title_required` | Page title is required. |
 
-## Usage Guide
+### Widget Module Messages
+
+| Key | Message |
+|-----|---------|
+| `validation.widget.title_required` | Widget title is required. |
+| `validation.widget.type_required` | Widget type is required. |
+
+---
+
+## 6. Usage Guide
 
 ### In Controllers
 
@@ -200,30 +208,56 @@ class MyController
 
 ### Adding Validation to New Entities
 
-1. Import the Symfony Validator constraints:
+1. Import the constraints:
    ```php
    use Symfony\Component\Validator\Constraints as Assert;
    use Pagekit\System\Validator\Constraints as PagekitAssert;
    ```
 
-2. Add attributes to properties:
+2. Add message keys to `validation.php`:
    ```php
-   #[Assert\NotBlank(message: 'Field is required.')]
+   'validation.myentity.field_required' => 'Field is required.',
+   ```
+
+3. Add attributes to properties:
+   ```php
+   #[Assert\NotBlank(message: 'validation.myentity.field_required')]
    #[Assert\Length(min: 3, max: 100)]
    public ?string $myField = '';
    ```
 
-3. For database uniqueness:
+4. For database uniqueness:
    ```php
    #[PagekitAssert\Unique(
        table: '@my_table',
        column: 'my_column',
-       message: 'Value already exists.'
+       message: 'validation.myentity.field_not_available'
    )]
    public ?string $uniqueField = '';
    ```
 
-## Hybrid Mode Notes
+---
+
+## 7. Error Response Format
+
+Validation errors are returned as JSON with the following structure:
+
+```json
+{
+  "error": true,
+  "message": "First error message for display",
+  "errors": {
+    "username": ["validation.user.username_required", "validation.user.username_min_length"],
+    "email": ["validation.user.email_invalid"]
+  }
+}
+```
+
+HTTP Status Code: **400 Bad Request**
+
+---
+
+## 8. Hybrid Mode Notes
 
 ### Why Hybrid?
 
@@ -237,107 +271,70 @@ The ORM still uses Doctrine Annotations (`doctrine/annotations` package) because
 All ORM annotations are marked with TODO comments:
 
 ```php
-/** @Column */
+/**
+ * @Column
+ */
 // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+#[Assert\NotBlank(message: 'validation.entity.field_required')]
+public ?string $field = null;
 ```
 
-### When Step 1.14 is Complete
+---
 
-After ORM Attributes migration:
-1. Replace `@Entity`, `@Column`, `@Id` annotations with `#[ORM\Entity]`, `#[ORM\Column]`, `#[ORM\Id]`
-2. Remove `// TODO: Must be refactored in Step 1.14` comments
-3. Update `doctrine/annotations` usage
+## 9. Files Changed
 
-## Migration from Manual Validation
-
-### Old Pattern (REMOVED)
-
-```php
-// In Entity
-public function validate(): bool
-{
-    if (empty($this->name)) {
-        throw new Exception(__('Name required.'));
-    }
-    return true;
-}
-
-// In Controller
-$user->validate();
-$user->save();
-```
-
-### New Pattern (CURRENT)
-
-```php
-// In Entity - just attributes, no validate() method
-#[Assert\NotBlank(message: 'Name is required.')]
-public ?string $name = null;
-
-// In Controller
-use ValidatesRequestTrait;
-// ...
-$this->validateOrFail($user);
-$user->save();
-```
-
-## Aggressive Modernization Rules Applied
-
-| Rule | Application |
-|------|-------------|
-| **#1 NO COMPATIBILITY LAYERS** | No shim classes created; all controllers updated directly |
-| **#2 NO ADAPTERS** | All `$user->validate()` calls replaced in the same commit |
-| **#3 BREAKING CHANGES ALLOWED** | Internal API changed (validate() method removed) |
-| **#4 DELETE OVER WRAP** | Old `validate()` method completely removed, not wrapped |
-| **#5 MANDATORY FLAGGING** | All ORM annotations marked with `// TODO: Must be refactored in Step 1.14` |
-
-## Files Changed
+### Phase 1
 
 ```
-Modified:
-- composer.json (added symfony/validator)
-- app/system/index.php (registered validator service)
-- app/system/modules/user/src/Model/User.php (added validation attributes, removed validate())
-- app/system/modules/user/src/Model/Role.php (added validation attributes)
-- app/system/modules/user/src/Controller/UserApiController.php (use ValidatesRequestTrait)
-- app/system/modules/user/src/Controller/RegistrationController.php (use ValidatesRequestTrait)
-- app/system/modules/user/src/Controller/ProfileController.php (use ValidatesRequestTrait)
-
 Created:
 - app/system/src/ValidatorServiceProvider.php
 - app/system/src/Controller/ValidatesRequestTrait.php
 - app/system/src/Validator/Constraints/Unique.php
 - app/system/src/Validator/Constraints/UniqueValidator.php
-- migration-docs/branches/VALIDATION_SYSTEM.md (this file)
+
+Modified:
+- composer.json (added symfony/validator)
+- app/system/index.php (registered validator service)
+- app/system/modules/user/src/Model/User.php
+- app/system/modules/user/src/Model/Role.php
+- app/system/modules/user/src/Controller/UserApiController.php
+- app/system/modules/user/src/Controller/RegistrationController.php
+- app/system/modules/user/src/Controller/ProfileController.php
 ```
 
-## Testing
+### Phase 2
 
-### Manual Tests
+```
+Created:
+- app/system/languages/en_US/validation.php
+- migration-docs/branches/VALIDATION_PHASE2_DISCOVERY.md
 
-1. **Page Load Test**: Access `/admin` - should redirect to login
-2. **Invalid Data Test**: Submit registration with empty fields - should return validation errors
-3. **Valid Data Test**: Submit valid registration - should succeed
-4. **ORM Test**: Load users via `User::find(1)` - should work correctly
+Modified:
+- app/system/modules/user/src/Model/User.php (updated to use message keys)
+- app/system/modules/user/src/Model/Role.php (updated to use message keys)
+- app/system/modules/user/src/Controller/RoleApiController.php (added ValidatesRequestTrait)
+- app/system/modules/site/src/Model/Node.php (added validation attributes)
+- app/system/modules/site/src/Model/Page.php (added validation attributes)
+- app/system/modules/site/src/Controller/NodeApiController.php (added ValidatesRequestTrait)
+- app/system/modules/widget/src/Model/Widget.php (added validation attributes)
+- app/system/modules/widget/src/Controller/WidgetApiController.php (added ValidatesRequestTrait)
+```
 
-### Automated Tests
+---
 
-TODO: Add unit tests for:
-- `ValidatorServiceProvider` registration
-- `ValidatesRequestTrait` methods
-- `Unique` constraint validator
-- User entity validation
+## 10. Aggressive Modernization Rules Applied
 
-## Rollback Plan
+| Rule | Application |
+|------|-------------|
+| **#1 NO COMPATIBILITY LAYERS** | No shim classes created; all controllers updated directly |
+| **#2 NO ADAPTERS** | All manual validation calls replaced in the same commit |
+| **#3 BREAKING CHANGES ALLOWED** | Internal API changed (validate() method removed) |
+| **#4 DELETE OVER WRAP** | Old `validate()` method and manual validation completely removed |
+| **#5 MANDATORY FLAGGING** | All ORM annotations marked with `// TODO: Must be refactored in Step 1.14` |
 
-If issues occur:
+---
 
-1. Revert the branch
-2. Remove `symfony/validator` from `composer.json`
-3. Run `composer update`
-4. Verify system works
-
-## Next Steps
+## 11. Next Steps
 
 1. **Step 1.14**: Migrate ORM from Annotations to Attributes
    - Replace `@Entity` with `#[ORM\Entity]`
@@ -345,9 +342,10 @@ If issues occur:
    - Remove `doctrine/annotations` dependency
    - Remove TODO comments
 
-2. Add validation to other entities as needed
+2. **Translation Integration**: Integrate message keys with `__()` function or Symfony Translator
 
-3. Consider adding more custom constraints:
-   - `#[UniqueEmail]` - Email uniqueness across multiple tables
+3. **Additional Entities**: Add validation to any remaining entities as needed
+
+4. **Custom Constraints**: Consider adding more custom constraints:
    - `#[StrongPassword]` - Password strength validation
    - `#[ValidSlug]` - URL slug validation

--- a/migration-docs/testing/VALIDATION_TESTING_GUIDE.md
+++ b/migration-docs/testing/VALIDATION_TESTING_GUIDE.md
@@ -1,0 +1,414 @@
+# Validation System Testing Guide
+
+## Overview
+
+This guide covers all manual and automated tests for the Symfony Validator integration (Step 1.13).
+
+## ✅ Manual Testing Checklist
+
+### 1. User Module Validation Tests
+
+#### 1.1 User Registration (`/admin/user` → Add User)
+
+**Required Fields:**
+- [ ] **Username** (min 3 chars, max 255, alphanumeric + dots/underscores/hyphens)
+  - ❌ Test: Empty username → Should show: "Username is required"
+  - ❌ Test: 2 characters → Should show: "Username must be at least 3 characters"
+  - ❌ Test: 256+ characters → Should show: "Username cannot exceed 255 characters"
+  - ❌ Test: Special chars (e.g., `user@name`, `user name`, `user#name`) → Should show: "Username is invalid. Only letters, numbers, dots, underscores and hyphens are allowed"
+  - ❌ Test: Duplicate username → Should show: "Username is not available"
+
+- [ ] **Email** (required, valid format, unique)
+  - ❌ Test: Empty email → Should show: "Email is required"
+  - ❌ Test: Invalid format (e.g., `notanemail`, `user@`, `@domain.com`) → Should show: "Email is invalid"
+  - ❌ Test: Duplicate email → Should show: "Email is not available"
+
+- [ ] **Name** (required, max 255 chars)
+  - ❌ Test: Empty name → Should show: "Name is required"
+  - ❌ Test: 256+ characters → Should show max length error
+
+- [ ] **Password** (required on registration only)
+  - ❌ Test: Empty password on new user → Should show: "Password is required"
+  - ✅ Test: Empty password on existing user → Should NOT validate (password unchanged)
+
+#### 1.2 User Profile Update (`/admin/user/edit/{id}`)
+
+**Update Validation:**
+- [ ] **Username uniqueness** - Try to change to existing username → Should show: "Username is not available"
+- [ ] **Email uniqueness** - Try to change to existing email → Should show: "Email is not available"
+- [ ] **Password optional** - Empty password should NOT trigger validation (only on registration)
+
+#### 1.3 User Registration (Public `/registration`)
+
+- [ ] Same tests as 1.1 (Required fields, formats, uniqueness)
+- [ ] Password required on registration
+
+---
+
+### 2. Role Module Validation Tests
+
+#### 2.1 Role Creation/Update (`/admin/user/role`)
+
+- [ ] **Name** (required, max length)
+  - ❌ Test: Empty name → Should show: "Role name is required"
+  - ❌ Test: 256+ characters → Should show max length error
+
+- [ ] **Priority** (non-negative number)
+  - ❌ Test: Negative number (e.g., -1) → Should show: "Priority must be a non-negative number"
+  - ✅ Test: Zero → Should work
+  - ✅ Test: Positive number → Should work
+
+---
+
+### 3. Site Module Validation Tests
+
+#### 3.1 Node Creation/Update (`/admin/site/page` → Add/Edit Page)
+
+- [ ] **Title** (required, max 255 chars)
+  - ❌ Test: Empty title → Should show: "Title is required"
+  - ❌ Test: 256+ characters → Should show max length error
+
+- [ ] **Slug** (required, regex pattern `/^[a-z0-9\-_]+$/`, max 255)
+  - ❌ Test: Empty slug (generated from title if empty) → If title also empty, should fail
+  - ❌ Test: Invalid chars (e.g., `My Page`, `page@123`, `page#test`) → Should show: "Invalid slug. Only lowercase letters, numbers, hyphens and underscores are allowed"
+  - ❌ Test: Uppercase letters (e.g., `MyPage`) → Should show invalid slug error
+  - ❌ Test: 256+ characters → Should show max length error
+  - ✅ Test: Valid slug (e.g., `my-page`, `page_123`, `test-page-1`) → Should work
+
+- [ ] **Link** (max 500 chars, optional)
+  - ❌ Test: 501+ characters → Should show max length error
+  - ✅ Test: Valid URL/route → Should work
+
+- [ ] **Type** (required)
+  - ❌ Test: Empty type → Should show: "Type is required"
+
+- [ ] **Status** (Choice: 0 or 1)
+  - ❌ Test: Invalid status (e.g., 2, -1) → Should show: "Status is invalid"
+  - ✅ Test: Status 0 (inactive) → Should work
+  - ✅ Test: Status 1 (active) → Should work
+
+#### 3.2 Page Entity (part of Node)
+
+- [ ] **Page Title** (required, max 255)
+  - ❌ Test: Empty title → Should show: "Page title is required"
+  - ❌ Test: 256+ characters → Should show max length error
+
+---
+
+### 4. Widget Module Validation Tests
+
+#### 4.1 Widget Creation/Update (`/admin/site/widget` → Add/Edit Widget)
+
+- [ ] **Title** (required, max 255 chars)
+  - ❌ Test: Empty title → Should show: "Widget title is required"
+  - ❌ Test: 256+ characters → Should show max length error
+
+- [ ] **Type** (required)
+  - ❌ Test: Empty type → Should show: "Widget type is required"
+
+- [ ] **Status** (Choice: 0 or 1)
+  - ❌ Test: Invalid status (e.g., 2, -1) → Should show: "Status is invalid"
+  - ✅ Test: Status 0 (inactive) → Should work
+  - ✅ Test: Status 1 (active) → Should work
+
+---
+
+### 5. Error Response Format Tests
+
+#### 5.1 JSON Error Structure
+
+For ALL validation failures, verify:
+- [ ] HTTP Status Code: **400 Bad Request**
+- [ ] Response format:
+  ```json
+  {
+    "error": true,
+    "message": "First error message for display",
+    "errors": {
+      "field_name": ["Error message 1", "Error message 2"],
+      "another_field": ["Error message"]
+    }
+  }
+  ```
+- [ ] Errors are grouped by field name
+- [ ] Multiple errors per field are shown as array
+
+#### 5.2 Frontend Integration
+
+**⚠️ Current State (Dual Validation System):**
+
+- [ ] **Client-Side Validation (Vue.js / vee-validate)**
+  - ✅ Errors appear below form fields BEFORE submit
+  - ✅ Error messages are translated
+  - ✅ Form submission is blocked when validation fails
+  - ✅ Error styling (red borders, error text) is applied
+  - ✅ **Example**: `v-input` with `:rules="{required: true, regex: /^[a-zA-Z0-9._\-]+$/}"`
+
+- [ ] **Backend Validation (Symfony Validator)**
+  - ⚠️ **Currently**: Backend errors shown as generic notification (not field-specific)
+  - ⚠️ **TODO**: Backend validation errors should be displayed as structured field errors
+  - ✅ Validation happens AFTER submit (server-side)
+  - ✅ Catches edge cases that client-side validation might miss
+  - ⚠️ **Note**: `validateOrFail()` throws exception with first error message only
+
+**Current Frontend Error Handling:**
+```javascript
+// Example from user-edit.js
+}, function (res) {
+    this.$notify(res.data, 'danger');  // ← Generic notification only
+})
+```
+
+**Future Improvement Needed:**
+- Display backend validation errors per field (like client-side validation)
+- Use `response.data.errors` object to show errors below respective form fields
+- This will be addressed in future Vue.js migration (Step 2.1.5+)
+
+---
+
+## 🧪 Unit Testing Recommendations
+
+### Why Unit Tests?
+
+**YES, Unit Tests are highly recommended** for validation because:
+
+1. **Automated Verification** - Catch regressions automatically
+2. **Fast Feedback** - Run tests in seconds vs. manual testing (minutes)
+3. **Edge Case Coverage** - Test boundary conditions easily (min/max lengths, special chars)
+4. **Documentation** - Tests serve as living documentation of validation rules
+5. **CI/CD Integration** - Prevent broken code from reaching production
+
+### Recommended Test Structure
+
+#### Test File Locations
+
+```
+tests/unit/Validator/
+├── UniqueValidatorTest.php        # Test custom Unique constraint
+├── UserValidationTest.php         # Test User entity validation
+├── RoleValidationTest.php         # Test Role entity validation
+├── NodeValidationTest.php         # Test Node entity validation
+├── PageValidationTest.php         # Test Page entity validation
+└── WidgetValidationTest.php       # Test Widget entity validation
+```
+
+#### Example Test Structure
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\Tests\Unit\Validator;
+
+use Pagekit\User\Model\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class UserValidationTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        // Get validator from app container
+        $app = \Pagekit\Application::getInstance();
+        $this->validator = $app['validator'];
+    }
+
+    public function testUsernameRequired(): void
+    {
+        $user = new User();
+        $user->email = 'test@example.com';
+        $user->name = 'Test User';
+
+        $violations = $this->validator->validate($user);
+
+        $this->assertGreaterThan(0, count($violations));
+        $this->assertStringContainsString('username', (string) $violations[0]->getPropertyPath());
+        $this->assertStringContainsString('required', $violations[0]->getMessage());
+    }
+
+    public function testUsernameMinLength(): void
+    {
+        $user = new User();
+        $user->username = 'ab'; // 2 chars - too short
+        $user->email = 'test@example.com';
+        $user->name = 'Test User';
+
+        $violations = $this->validator->validate($user);
+
+        $this->assertGreaterThan(0, count($violations));
+        // Check for min length violation
+    }
+
+    public function testUsernameRegex(): void
+    {
+        $user = new User();
+        $user->username = 'user@name'; // Invalid chars
+        $user->email = 'test@example.com';
+        $user->name = 'Test User';
+
+        $violations = $this->validator->validate($user);
+
+        $this->assertGreaterThan(0, count($violations));
+        // Check for regex violation
+    }
+
+    public function testEmailFormat(): void
+    {
+        $user = new User();
+        $user->username = 'testuser';
+        $user->email = 'notanemail'; // Invalid format
+        $user->name = 'Test User';
+
+        $violations = $this->validator->validate($user);
+
+        $this->assertGreaterThan(0, count($violations));
+        // Check for email format violation
+    }
+
+    // ... more tests for each constraint
+}
+```
+
+### Test Coverage Checklist
+
+#### User Entity Tests
+- [ ] Username required
+- [ ] Username min length (3 chars)
+- [ ] Username max length (255 chars)
+- [ ] Username regex pattern
+- [ ] Username uniqueness (new user)
+- [ ] Username uniqueness (update - exclude self)
+- [ ] Email required
+- [ ] Email format validation
+- [ ] Email uniqueness (new user)
+- [ ] Email uniqueness (update - exclude self)
+- [ ] Name required
+- [ ] Name max length (255 chars)
+- [ ] Password required (registration group only)
+- [ ] Password optional (update, no registration group)
+- [ ] Status choice validation (0 or 1)
+
+#### Role Entity Tests
+- [ ] Name required
+- [ ] Name max length
+- [ ] Priority non-negative (PositiveOrZero)
+
+#### Node Entity Tests
+- [ ] Slug required
+- [ ] Slug regex pattern
+- [ ] Slug max length
+- [ ] Title required
+- [ ] Title max length
+- [ ] Link max length (optional)
+- [ ] Type required
+- [ ] Status choice (0 or 1)
+- [ ] Priority non-negative
+- [ ] Parent ID non-negative
+
+#### Page Entity Tests
+- [ ] Title required
+- [ ] Title max length
+
+#### Widget Entity Tests
+- [ ] Title required
+- [ ] Title max length
+- [ ] Type required
+- [ ] Status choice (0 or 1)
+
+#### UniqueValidator Tests
+- [ ] Unique constraint works for new records
+- [ ] Unique constraint excludes current record on update
+- [ ] Unique constraint uses correct table and column
+- [ ] Unique constraint handles null/empty values correctly
+
+---
+
+## 🚀 Quick Test Commands
+
+### Manual Testing via Browser
+
+1. **User Registration:**
+   ```
+   http://localhost:8000/admin/user
+   → Click "Add User"
+   → Try saving with empty/invalid data
+   ```
+
+2. **Node Creation:**
+   ```
+   http://localhost:8000/admin/site/page
+   → Click "Add Page"
+   → Try saving with empty/invalid data
+   ```
+
+3. **Widget Creation:**
+   ```
+   http://localhost:8000/admin/site/widget
+   → Click "Add Widget"
+   → Try saving with empty/invalid data
+   ```
+
+### API Testing via curl (if API endpoints are accessible)
+
+```bash
+# Test User validation
+curl -X POST http://localhost:8000/api/user \
+  -H "Content-Type: application/json" \
+  -d '{"user": {"username": "", "email": "invalid"}}'
+# Should return 400 with validation errors
+
+# Test Node validation
+curl -X POST http://localhost:8000/api/site/node \
+  -H "Content-Type: application/json" \
+  -d '{"node": {"title": "", "slug": "INVALID SLUG"}}'
+# Should return 400 with validation errors
+```
+
+---
+
+## 📊 Test Priority
+
+### High Priority (Must Test)
+1. ✅ **User Registration** - Critical security feature
+2. ✅ **Username/Email Uniqueness** - Prevents duplicate accounts
+3. ✅ **Node Slug Validation** - Prevents invalid URLs
+4. ✅ **Required Fields** - Basic functionality
+
+### Medium Priority (Should Test)
+1. ⚠️ **Length Constraints** - Data integrity
+2. ⚠️ **Regex Patterns** - Format validation
+3. ⚠️ **Choice Validation** (Status, etc.) - Enum validation
+
+### Low Priority (Nice to Have)
+1. ℹ️ **Update Context** - Unique constraint excludes self
+2. ℹ️ **Validation Groups** - Password on registration only
+
+---
+
+## 🎯 Success Criteria
+
+**All tests pass if:**
+- ✅ Invalid data returns 400 Bad Request
+- ✅ Error messages are clear and helpful
+- ✅ Error format matches expected JSON structure
+- ✅ Frontend displays errors correctly
+- ✅ Valid data saves successfully
+- ✅ No PHP errors in logs
+- ✅ No JavaScript errors in browser console
+
+---
+
+## 📝 Notes
+
+- **Translation**: Currently using message keys (not translated yet) - translation integration will come later
+- **Frontend Validation**: 
+  - ✅ **Client-Side Validation (Vue.js / vee-validate)**: Still active and working - validates BEFORE submit, shows field-specific errors
+  - ⚠️ **Backend Validation (Symfony Validator)**: Validates AFTER submit, currently shows only generic notifications (not field-specific errors)
+  - 📌 **Dual System**: Both validations work in parallel:
+    1. Client-side catches most errors before submit (better UX)
+    2. Backend validation catches edge cases and ensures data integrity (security)
+  - 🔮 **Future**: Backend validation errors will be displayed as structured field errors in Vue.js migration (Step 2.1.5+)
+- **Business Logic**: Some validation (like "Invalid type" for protected nodes) is business logic, not entity validation - these remain in controllers

--- a/packages/pagekit/blog/app/views/reply.vue
+++ b/packages/pagekit/blog/app/views/reply.vue
@@ -25,7 +25,7 @@
 
                     <div class="uk-margin">
                         <label for="form-email" class="uk-form-label">{{ 'Email' | trans }}</label>
-                        <v-input id="form-email" v-model="email" name="email" type="email" view="class: uk-input uk-form-width-large" rules="required|email" message="Email invalid." />
+                        <v-input id="form-email" v-model="email" name="email" type="email" view="class: uk-input uk-form-width-large" :rules="emailRules" message="Email invalid." />
                     </div>
                 </template>
 
@@ -84,6 +84,12 @@ export default {
 
         login() {
             return this.$url('user/login', { redirect: window.location.href });
+        },
+
+        emailRules() {
+            // Use requireinfo from config (set by SiteController based on blog settings)
+            // If requireinfo is true, email is required; otherwise only validate format if provided
+            return this.config.requireinfo ? 'required|email' : 'email';
         }
 
     },

--- a/packages/pagekit/blog/languages/en_US/validation.php
+++ b/packages/pagekit/blog/languages/en_US/validation.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Blog Extension - Validation Messages (Symfony Validator)
+ *
+ * These messages are used with Symfony Validator attributes in Blog entities.
+ * Message keys follow pattern: validation.{entity}.{field}_{constraint}
+ */
+
+return [
+
+    // ============================================================
+    // POST ENTITY
+    // ============================================================
+
+    'validation.post.title_required' => 'Title cannot be blank.',
+    'validation.post.title_max_length' => 'Title cannot exceed {{ limit }} characters.',
+
+    'validation.post.slug_required' => 'Slug is required.',
+    'validation.post.slug_invalid' => 'Invalid slug.',
+    'validation.post.slug_max_length' => 'Slug cannot exceed {{ limit }} characters.',
+
+    'validation.post.status_invalid' => 'Invalid post status.',
+
+    'validation.post.user_required' => 'Author is required.',
+
+    // ============================================================
+    // COMMENT ENTITY
+    // ============================================================
+
+    'validation.comment.author_required' => 'Author cannot be blank.',
+    'validation.comment.author_max_length' => 'Author name cannot exceed {{ limit }} characters.',
+
+    'validation.comment.content_required' => 'Content cannot be blank.',
+
+    'validation.comment.email_invalid' => 'Field must be a valid email address.',
+
+    'validation.comment.url_invalid' => 'URL is invalid.',
+
+    'validation.comment.post_required' => 'Post is required.',
+
+    'validation.comment.status_invalid' => 'Invalid comment status.',
+
+];

--- a/packages/pagekit/blog/src/Controller/CommentApiController.php
+++ b/packages/pagekit/blog/src/Controller/CommentApiController.php
@@ -1,18 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\Blog\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Blog\Model\Comment;
 use Pagekit\Blog\Model\Post;
+use Pagekit\System\Controller\ValidatesRequestTrait;
 use Pagekit\User\Model\User;
 use Pagekit\Module\Module;
+use function Pagekit\__;
 
 /**
+ * API Controller for Blog Comment management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Route("comment", name="comment")
  */
 class CommentApiController
 {
+    use ValidatesRequestTrait;
+
     protected Module $blog;
     protected User $user;
 
@@ -26,7 +36,7 @@ class CommentApiController
      * @Route("/", methods="GET")
      * @Request({"filter": "array", "post":"int", "page":"int", "limit":"int"})
      */
-    public function indexAction($filter = [], $post = 0, $page = 0, $limit = 0): array
+    public function indexAction(array $filter = [], int $post = 0, int $page = 0, int $limit = 0): array
     {
         $query = Comment::query();
         $filter = array_merge(array_fill_keys(['status', 'search', 'order'], ''), $filter);
@@ -113,12 +123,16 @@ class CommentApiController
     }
 
     /**
+     * Save a comment (create or update).
+     *
+     * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      * @Request({"comment": "array", "id": "int"}, csrf=true)
      * @Captcha(verify="true")
      */
-    public function saveAction($data, $id = 0): array
+    public function saveAction(array $data, int $id = 0): array
     {
         if (!$id) {
 
@@ -133,6 +147,8 @@ class CommentApiController
                 $data['email'] = $this->user->email;
                 $data['url'] = $this->user->url;
             } elseif ($this->blog->config('comments.require_email') && (!@$data['author'] || !@$data['email'])) {
+                // Business logic: require email only for anonymous users when config is enabled
+                // This is a conditional validation that cannot be easily expressed with static attributes
                 App::abort(400, __('Please provide valid name and email.'));
             }
 
@@ -156,7 +172,7 @@ class CommentApiController
 
         unset($data['created']);
 
-        // check minimum idle time in between user comments
+        // check minimum idle time in between user comments (business logic)
         if (!$this->user->hasAccess('blog: skip comment min idle')
             and $minidle = $this->blog->config('comments.minidle')
             and $commentIdle = Comment::where($this->user->isAuthenticated() ? ['user_id' => $this->user->id] : ['ip' => App::request()->getClientIp()])->orderBy('created', 'DESC')->first()
@@ -180,7 +196,7 @@ class CommentApiController
         $approved_once = (boolean) Comment::where(['user_id' => $this->user->id, 'status' => Comment::STATUS_APPROVED])->first();
         $comment->status = $this->user->hasAccess('blog: skip comment approval') ? Comment::STATUS_APPROVED : ($this->user->hasAccess('blog: comment approval required once') && $approved_once ? Comment::STATUS_APPROVED : Comment::STATUS_PENDING);
 
-        // check the max links rule
+        // check the max links rule (business logic)
         if ($comment->status == Comment::STATUS_APPROVED && $this->blog->config('comments.maxlinks') <= preg_match_all('/<a [^>]*href/i', @$data['content'])) {
             $comment->status = Comment::STATUS_PENDING;
         }
@@ -190,6 +206,12 @@ class CommentApiController
 
         $comment->save($data);
 
+        // Validate using Symfony Validator (Step 1.13 - Hybrid Mode)
+        // Note: Some validations remain as business logic above (require_email for anonymous users)
+        $this->validateOrFail($comment);
+
+        $comment->save();
+
         return ['message' => 'success', 'comment' => $comment];
     }
 
@@ -198,7 +220,7 @@ class CommentApiController
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      * @Request({"id": "int"}, csrf=true)
      */
-    public function deleteAction($id): array
+    public function deleteAction(int $id): array
     {
         if ($comment = Comment::find($id)) {
             $comment->delete();
@@ -212,7 +234,7 @@ class CommentApiController
      * @Route("/bulk", methods="POST")
      * @Request({"comments": "array"}, csrf=true)
      */
-    public function bulkSaveAction($comments = []): array
+    public function bulkSaveAction(array $comments = []): array
     {
 
         foreach ($comments as $data) {
@@ -227,7 +249,7 @@ class CommentApiController
      * @Route("/bulk", methods="DELETE")
      * @Request({"ids": "array"}, csrf=true)
      */
-    public function bulkDeleteAction($ids = []): array
+    public function bulkDeleteAction(array $ids = []): array
     {
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);

--- a/packages/pagekit/blog/src/Controller/CommentApiController.php
+++ b/packages/pagekit/blog/src/Controller/CommentApiController.php
@@ -171,7 +171,9 @@ class CommentApiController
 
         }
 
-        unset($data['created']);
+        // Security: Remove server-controlled fields from client data to prevent spoofing
+        // These fields are set by the server (user_id, ip, created) and must not be overwritten by client
+        unset($data['created'], $data['user_id'], $data['ip']);
 
         // check minimum idle time in between user comments (business logic)
         if (!$this->user->hasAccess('blog: skip comment min idle')

--- a/packages/pagekit/blog/src/Controller/CommentApiController.php
+++ b/packages/pagekit/blog/src/Controller/CommentApiController.php
@@ -152,7 +152,8 @@ class CommentApiController
                 App::abort(400, __('Please provide valid name and email.'));
             }
 
-            $comment->user_id = $this->user->isAuthenticated() ? (int) $this->user->id : 0;
+            // user_id stored as string in database (legacy), use '0' for anonymous users
+            $comment->user_id = $this->user->isAuthenticated() ? (string) $this->user->id : '0';
             $comment->ip = App::request()->getClientIp();
             $comment->created = new \DateTime;
 

--- a/packages/pagekit/blog/src/Controller/CommentApiController.php
+++ b/packages/pagekit/blog/src/Controller/CommentApiController.php
@@ -205,13 +205,18 @@ class CommentApiController
         // check for spam
         //App::trigger('system.comment.spam_check', new CommentEvent($comment));
 
-        $comment->save($data);
+        // Assign data to entity for validation (without saving yet)
+        foreach ($data as $key => $value) {
+            if (property_exists($comment, $key)) {
+                $comment->$key = $value;
+            }
+        }
 
         // Validate using Symfony Validator (Step 1.13 - Hybrid Mode)
         // Note: Some validations remain as business logic above (require_email for anonymous users)
         $this->validateOrFail($comment);
 
-        $comment->save();
+        $comment->save($data);
 
         return ['message' => 'success', 'comment' => $comment];
     }

--- a/packages/pagekit/blog/src/Controller/PostApiController.php
+++ b/packages/pagekit/blog/src/Controller/PostApiController.php
@@ -127,8 +127,10 @@ class PostApiController
         }
 
         // Assign data to entity for validation (without saving yet)
+        // Skip DateTime fields - save() handles string-to-DateTime conversion
+        $skipFields = ['date', 'modified', 'created'];
         foreach ($data as $key => $value) {
-            if (property_exists($post, $key)) {
+            if (property_exists($post, $key) && !in_array($key, $skipFields, true)) {
                 $post->$key = $value;
             }
         }

--- a/packages/pagekit/blog/src/Controller/PostApiController.php
+++ b/packages/pagekit/blog/src/Controller/PostApiController.php
@@ -1,16 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pagekit\Blog\Controller;
 
 use Pagekit\Application as App;
 use Pagekit\Blog\Model\Post;
+use Pagekit\System\Controller\ValidatesRequestTrait;
+use function Pagekit\__;
 
 /**
+ * API Controller for Blog Post management.
+ *
+ * Uses Symfony Validator for entity validation (Step 1.13 - Hybrid Mode).
+ *
  * @Access("blog: manage own posts || blog: manage all posts")
  * @Route("post", name="post")
  */
 class PostApiController
 {
+    use ValidatesRequestTrait;
+
     /**
      * @Route("/", methods="GET")
      */
@@ -20,7 +30,7 @@ class PostApiController
         $request = App::request();
         $filter = $request->query->all()['filter'] ?? [];
         $page = (int) $request->query->get('page', 0);
-        
+
         $query  = Post::query();
         $filter = array_merge(array_fill_keys(['status', 'search', 'author', 'order', 'limit'], ''), $filter);
 
@@ -63,33 +73,37 @@ class PostApiController
     /**
      * @Route("/{id}", methods="GET", requirements={"id"="\d+"})
      */
-    public function getAction($id)
+    public function getAction(int $id)
     {
         return Post::where(compact('id'))->related('user', 'comments')->first();
     }
 
     /**
+     * Save a post (create or update).
+     *
+     * Uses Symfony Validator for validation (replaces manual slug validation).
+     *
      * @Route("/", methods="POST")
      * @Route("/{id}", methods="POST", requirements={"id"="\d+"})
      */
-    public function saveAction($id = 0, $data = null): array
+    public function saveAction(int $id = 0, ?array $data = null): array
     {
         // Get parameters from request if not provided (Symfony 6.4 compatibility)
         if ($data === null) {
             $request = App::request();
-            
+
             $data = $request->request->all()['post'] ?? [];
             if (empty($data) && $request->getContent()) {
                 $json = json_decode($request->getContent(), true);
                 $data = $json['post'] ?? [];
             }
         }
-        
+
         // Get id from route or data
         if (!$id && isset($data['id'])) {
             $id = (int) $data['id'];
         }
-        
+
         if (!$id || !$post = Post::find($id)) {
 
             if ($id) {
@@ -99,21 +113,26 @@ class PostApiController
             $post = Post::create();
         }
 
-        if (!$data['slug'] = App::filter($data['slug'] ?: $data['title'], 'slugify')) {
-            App::abort(400, __('Invalid slug.'));
-        }
+        // Generate slug from title if not provided (business logic)
+        $data['slug'] = App::filter($data['slug'] ?: $data['title'], 'slugify');
 
         // user without universal access is not allowed to assign posts to other users
         if(!App::user()->hasAccess('blog: manage all posts')) {
             $data['user_id'] = App::user()->id;
         }
 
-        // user without universal access can only edit their own posts
+        // user without universal access can only edit their own posts (business logic, not entity validation)
         if(!App::user()->hasAccess('blog: manage all posts') && !App::user()->hasAccess('blog: manage own posts') && $post->user_id !== App::user()->id) {
             App::abort(400, __('Access denied.'));
         }
 
         $post->save($data);
+
+        // Validate using Symfony Validator (replaces manual slug validation)
+        // Rule #4: DELETE OVER WRAP - old manual check removed
+        $this->validateOrFail($post);
+
+        $post->save();
 
         return ['message' => 'success', 'post' => $post];
     }
@@ -121,15 +140,16 @@ class PostApiController
     /**
      * @Route("/{id}", methods="DELETE", requirements={"id"="\d+"})
      */
-    public function deleteAction($id = 0): array
+    public function deleteAction(int $id = 0): array
     {
         // Get id from route if not provided (Symfony 6.4 compatibility)
         if (!$id) {
             $id = (int) App::request()->get('id', 0);
         }
-        
+
         if ($post = Post::find($id)) {
 
+            // Business logic: user without universal access can only delete their own posts
             if(!App::user()->hasAccess('blog: manage all posts') && !App::user()->hasAccess('blog: manage own posts') && $post->user_id !== App::user()->id) {
                 App::abort(400, __('Access denied.'));
             }
@@ -147,13 +167,13 @@ class PostApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach ($ids as $id) {
             if ($post = Post::find((int) $id)) {
                 if(!App::user()->hasAccess('blog: manage all posts') && !App::user()->hasAccess('blog: manage own posts') && $post->user_id !== App::user()->id) {
@@ -180,13 +200,13 @@ class PostApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $posts = $request->request->all()['posts'] ?? [];
         if (empty($posts) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $posts = $json['posts'] ?? [];
         }
-        
+
         foreach ($posts as $data) {
             $id = isset($data['id']) ? $data['id'] : 0;
             $this->saveAction($id, $data);
@@ -202,13 +222,13 @@ class PostApiController
     {
         // Get parameters from request (Symfony 6.4 compatibility)
         $request = App::request();
-        
+
         $ids = $request->request->all()['ids'] ?? [];
         if (empty($ids) && $request->getContent()) {
             $json = json_decode($request->getContent(), true);
             $ids = $json['ids'] ?? [];
         }
-        
+
         foreach (array_filter($ids) as $id) {
             $this->deleteAction($id);
         }

--- a/packages/pagekit/blog/src/Controller/PostApiController.php
+++ b/packages/pagekit/blog/src/Controller/PostApiController.php
@@ -126,13 +126,18 @@ class PostApiController
             App::abort(400, __('Access denied.'));
         }
 
-        $post->save($data);
+        // Assign data to entity for validation (without saving yet)
+        foreach ($data as $key => $value) {
+            if (property_exists($post, $key)) {
+                $post->$key = $value;
+            }
+        }
 
         // Validate using Symfony Validator (replaces manual slug validation)
         // Rule #4: DELETE OVER WRAP - old manual check removed
         $this->validateOrFail($post);
 
-        $post->save();
+        $post->save($data);
 
         return ['message' => 'success', 'post' => $post];
     }

--- a/packages/pagekit/blog/src/Model/Comment.php
+++ b/packages/pagekit/blog/src/Model/Comment.php
@@ -21,7 +21,7 @@ class Comment extends BaseComment implements \JsonSerializable
      * @Column(type="integer")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\NotBlank(message: 'validation.blog_comment.post_required')]
+    #[Assert\NotBlank(message: 'validation.comment.post_required')]
     #[Assert\Positive]
     public int $post_id;
 
@@ -35,14 +35,14 @@ class Comment extends BaseComment implements \JsonSerializable
      * @Column(type="string")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\Email(message: 'validation.blog_comment.email_invalid')]
+    #[Assert\Email(message: 'validation.comment.email_invalid')]
     public ?string $email = null;
 
     /**
      * @Column(type="string")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    #[Assert\Url(message: 'validation.blog_comment.url_invalid')]
+    #[Assert\Url(message: 'validation.comment.url_invalid')]
     public ?string $url = '';
 
     /**

--- a/packages/pagekit/blog/src/Model/Comment.php
+++ b/packages/pagekit/blog/src/Model/Comment.php
@@ -5,31 +5,62 @@ declare(strict_types=1);
 namespace Pagekit\Blog\Model;
 
 use Pagekit\Comment\Model\Comment as BaseComment;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * Blog Comment entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@blog_comment")
  */
 class Comment extends BaseComment implements \JsonSerializable
 {
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.blog_comment.post_required')]
+    #[Assert\Positive]
     public int $post_id;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $user_id = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Email(message: 'validation.blog_comment.email_invalid')]
     public ?string $email = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Url(message: 'validation.blog_comment.url_invalid')]
     public ?string $url = '';
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $ip = null;
 
-    /** @BelongsTo(targetEntity="Post", keyFrom="post_id") */
+    /**
+     * @BelongsTo(targetEntity="Post", keyFrom="post_id")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public mixed $post = null;
 
-    /** @BelongsTo(targetEntity="Pagekit\User\Model\User", keyFrom="user_id") */
+    /**
+     * @BelongsTo(targetEntity="Pagekit\User\Model\User", keyFrom="user_id")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public mixed $user = null;
 
     /** @var int */

--- a/packages/pagekit/blog/src/Model/Comment.php
+++ b/packages/pagekit/blog/src/Model/Comment.php
@@ -42,8 +42,10 @@ class Comment extends BaseComment implements \JsonSerializable
      * @Column(type="string")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    // URL is optional. Symfony's Url constraint validates format when provided but accepts null for optional fields.
+    // Empty strings are converted to null via __set() magic method since Url constraint rejects empty strings.
     #[Assert\Url(message: 'validation.comment.url_invalid')]
-    public ?string $url = '';
+    public ?string $url = null;
 
     /**
      * @Column(type="string")
@@ -89,5 +91,29 @@ class Comment extends BaseComment implements \JsonSerializable
             self::STATUS_PENDING  => __('Pending'),
             self::STATUS_SPAM     => __('Spam')
         ];
+    }
+
+    /**
+     * Magic setter to normalize URL field values.
+     *
+     * Converts empty strings to null for the URL field. Symfony's Url constraint accepts null
+     * (optional field) but rejects empty strings. This normalization ensures consistent behavior
+     * when empty strings are assigned from form data or API requests.
+     *
+     * @param string $name Property name
+     * @param mixed $value Property value
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        if ($name === 'url' && $value === '') {
+            $value = null;
+        }
+
+        // Call parent setter if available
+        if (method_exists(get_parent_class($this), '__set')) {
+            parent::__set($name, $value);
+        } else {
+            $this->$name = $value;
+        }
     }
 }

--- a/packages/pagekit/blog/src/Model/Comment.php
+++ b/packages/pagekit/blog/src/Model/Comment.php
@@ -42,10 +42,10 @@ class Comment extends BaseComment implements \JsonSerializable
      * @Column(type="string")
      */
     // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
-    // URL is optional. Symfony's Url constraint validates format when provided but accepts null for optional fields.
-    // Empty strings are converted to null via __set() magic method since Url constraint rejects empty strings.
+    // URL is optional. Symfony's Url constraint validates format when provided.
+    // Both null and empty strings are accepted (constraint returns early for empty values).
     #[Assert\Url(message: 'validation.comment.url_invalid')]
-    public ?string $url = null;
+    public ?string $url = '';
 
     /**
      * @Column(type="string")
@@ -91,29 +91,5 @@ class Comment extends BaseComment implements \JsonSerializable
             self::STATUS_PENDING  => __('Pending'),
             self::STATUS_SPAM     => __('Spam')
         ];
-    }
-
-    /**
-     * Magic setter to normalize URL field values.
-     *
-     * Converts empty strings to null for the URL field. Symfony's Url constraint accepts null
-     * (optional field) but rejects empty strings. This normalization ensures consistent behavior
-     * when empty strings are assigned from form data or API requests.
-     *
-     * @param string $name Property name
-     * @param mixed $value Property value
-     */
-    public function __set(string $name, mixed $value): void
-    {
-        if ($name === 'url' && $value === '') {
-            $value = null;
-        }
-
-        // Call parent setter if available
-        if (method_exists(get_parent_class($this), '__set')) {
-            parent::__set($name, $value);
-        } else {
-            $this->$name = $value;
-        }
     }
 }

--- a/packages/pagekit/blog/src/Model/Post.php
+++ b/packages/pagekit/blog/src/Model/Post.php
@@ -8,8 +8,14 @@ use Pagekit\Application as App;
 use Pagekit\System\Model\DataModelTrait;
 use Pagekit\User\Model\AccessModelTrait;
 use Pagekit\User\Model\User;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * Blog Post entity with Symfony Validator integration (Hybrid Mode).
+ *
+ * Validation: Uses PHP 8 Attributes (#[Assert\...])
+ * ORM: Still uses Doctrine Annotations (@Entity, @Column) - TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+ *
  * @Entity(tableClass="@blog_post")
  */
 class Post implements \JsonSerializable
@@ -17,59 +23,115 @@ class Post implements \JsonSerializable
     use AccessModelTrait, DataModelTrait, PostModelTrait;
 
     /* Post draft status. */
-    const STATUS_DRAFT = 0;
+    public const STATUS_DRAFT = 0;
 
     /* Post pending review status. */
-    const STATUS_PENDING_REVIEW = 1;
+    public const STATUS_PENDING_REVIEW = 1;
 
     /* Post published. */
-    const STATUS_PUBLISHED = 2;
+    public const STATUS_PUBLISHED = 2;
 
     /* Post unpublished. */
-    const STATUS_UNPUBLISHED = 3;
+    public const STATUS_UNPUBLISHED = 3;
 
-    /** @Column(type="integer") @Id */
+    /**
+     * @Column(type="integer") @Id
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?int $id = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.post.title_required')]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.post.title_max_length'
+    )]
     public ?string $title = null;
 
-    /** @Column(type="string") */
+    /**
+     * @Column(type="string")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.post.slug_required')]
+    #[Assert\Regex(
+        pattern: '/^[a-z0-9\-_]+$/',
+        message: 'validation.post.slug_invalid'
+    )]
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'validation.post.slug_max_length'
+    )]
     public ?string $slug = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\NotBlank(message: 'validation.post.user_required')]
+    #[Assert\Positive]
     public ?int $user_id = null;
 
-    /** @Column(type="datetime") */
+    /**
+     * @Column(type="datetime")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?\DateTime $date = null;
 
-    /** @Column(type="text") */
+    /**
+     * @Column(type="text")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $content = '';
 
-    /** @Column(type="text") */
+    /**
+     * @Column(type="text")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?string $excerpt = '';
 
-    /** @Column(type="smallint") */
+    /**
+     * @Column(type="smallint")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\Choice(
+        choices: [self::STATUS_DRAFT, self::STATUS_PENDING_REVIEW, self::STATUS_PUBLISHED, self::STATUS_UNPUBLISHED],
+        message: 'validation.post.status_invalid'
+    )]
     public ?int $status = null;
 
-    /** @Column(type="datetime") */
+    /**
+     * @Column(type="datetime")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?\DateTime $modified = null;
 
-    /** @Column(type="boolean") */
+    /**
+     * @Column(type="boolean")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public ?bool $comment_status = null;
 
-    /** @Column(type="integer") */
+    /**
+     * @Column(type="integer")
+     */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
+    #[Assert\PositiveOrZero]
     public int $comment_count = 0;
 
     /**
      * @BelongsTo(targetEntity="Pagekit\User\Model\User", keyFrom="user_id")
      */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public mixed $user = null;
 
     /**
      * @HasMany(targetEntity="Comment", keyFrom="id", keyTo="post_id")
      * @OrderBy({"created" = "DESC"})
      */
+    // TODO: Must be refactored in Step 1.14 (ORM Attributes migration)
     public mixed $comments = null;
 
     /** @var bool */
@@ -131,8 +193,8 @@ class Post implements \JsonSerializable
         ];
 
         if ($this->comments) {
-            $data['comments_pending'] = count(array_filter($this->comments, function($comment) { 
-                return $comment->status == Comment::STATUS_PENDING; 
+            $data['comments_pending'] = count(array_filter($this->comments, function($comment) {
+                return $comment->status == Comment::STATUS_PENDING;
             }));
         }
 


### PR DESCRIPTION
## Summary
- Complete Symfony Validator migration Phase 3 (blog package: Post & Comment)
- Fix custom UniqueValidator to use Pagekit QueryBuilder API
- Refactor Node/Widget controllers to avoid double save and align with validation flow
- Add centralized validation message file and detailed testing guide
- Respect blog comments require_email setting in frontend reply form

## Test plan
- Manual validation tests for User, Role, Node, Page, Widget, Blog Post, Blog Comment (valid/invalid data)
- Verified /admin and frontend load without 500 errors
- Created/edited users, roles, nodes, widgets, posts, comments successfully
- Tested blog comment form with require_email on/off (frontend & backend behavior)
- Checked logs: no remaining validation-related PHP errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes migration to Symfony Validator with PHP 8 attribute-based rules and standardized controller validation.
> 
> - Adds `ValidatorServiceProvider`, `ValidatesRequestTrait`, and custom `PagekitAssert\Unique` constraint; registers `$app['validator']`
> - Annotates entities with constraints: `User`, `Role`, `Node`, `Page`, `Widget`, base `Comment`, blog `Post` and `Comment`
> - Refactors controllers to use `validateOrFail()` and typed signatures: `UserApiController`, `RegistrationController`, `ProfileController`, `RoleApiController`, `NodeApiController`, `WidgetApiController`, blog `PostApiController`, `CommentApiController`
> - Removes manual checks (e.g., slug/link/title validation) and legacy `User::validate()`; keeps business-logic guards where applicable
> - Centralizes messages in `app/system/languages/en_US/validation.php` and `packages/pagekit/blog/languages/en_US/validation.php`; adds migration/testing docs
> - Minor UI tweak: blog `reply.vue` respects `require_email` setting
> - Bumps version to `1.0.46` and adds `symfony/validator` to `composer.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3140015fa2566cc1a96cba263758d41a97c98b7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->