### PR TITLE
Integration of ongoing changes

### DIFF
--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -1,5 +1,16 @@
 # Changelog 2025
 
+## Pagekit 1.0.47 - Routing Cache Fix (January 21, 2026)
+
+### 🔧 Fixes
+
+- **Routing cache race condition** - Fixed `ClassNotFoundError` when moving pages via drag & drop
+  - Added automatic cache invalidation when routes change (cache key or modified time)
+  - Added error handling with fallback to non-cached matcher/generator if cache file is corrupted
+  - Fixed cache key calculation to only include structural options (matcher, generator, cache path)
+  - Meta-options like `blog.permalink` no longer invalidate routing cache unnecessarily
+  - Prevents multiple unnecessary cache files from being created
+
 ## Pagekit 1.0.46 - Symfony Validator Integration (January 19, 2026)
 
 ### 🚀 Major Changes

--- a/app/modules/routing/src/Router.php
+++ b/app/modules/routing/src/Router.php
@@ -155,9 +155,24 @@ class Router implements RouterInterface, UrlGeneratorInterface
                     $this->writeCache($cache['file'], (new PhpMatcherDumper($this->getRouteCollection()))->dump($options));
                 }
 
-                require_once $cache['file'];
+                try {
+                    require_once $cache['file'];
 
-                $this->matcher = new $class($this->context);
+                    // Verify class exists after requiring the file
+                    if (!class_exists($class, false)) {
+                        // Class not found in cache file - regenerate cache
+                        $options = ['class' => $class, 'base_class' => $this->options['matcher']];
+                        $this->writeCache($cache['file'], (new PhpMatcherDumper($this->getRouteCollection()))->dump($options));
+                        require_once $cache['file'];
+                    }
+
+                    $this->matcher = new $class($this->context);
+
+                } catch (\Error $e) {
+                    // Fallback to non-cached matcher if cache file is corrupted or class not found
+                    $class = $this->options['matcher'];
+                    $this->matcher = new $class($this->getRouteCollection(), $this->context);
+                }
 
             } else {
 
@@ -185,9 +200,24 @@ class Router implements RouterInterface, UrlGeneratorInterface
                     $this->writeCache($cache['file'], (new UrlGeneratorDumper($this->getRouteCollection()))->dump($options));
                 }
 
-                require_once $cache['file'];
+                try {
+                    require_once $cache['file'];
 
-                $this->generator = new $class($this->context);
+                    // Verify class exists after requiring the file
+                    if (!class_exists($class, false)) {
+                        // Class not found in cache file - regenerate cache
+                        $options = ['class' => $class, 'base_class' => $this->options['generator']];
+                        $this->writeCache($cache['file'], (new UrlGeneratorDumper($this->getRouteCollection()))->dump($options));
+                        require_once $cache['file'];
+                    }
+
+                    $this->generator = new $class($this->context);
+
+                } catch (\Error $e) {
+                    // Fallback to non-cached generator if cache file is corrupted or class not found
+                    $class = $this->options['generator'];
+                    $this->generator = new $class($this->getRouteCollection(), $this->context);
+                }
 
             } else {
 
@@ -286,8 +316,25 @@ class Router implements RouterInterface, UrlGeneratorInterface
             return null;
         }
 
-        if (!$this->cache) {
-            $this->cache = ['key' => sha1(serialize($this->resource).serialize($this->options)), 'modified' => $this->resource->getModified()];
+        // Only include structural options in cache key (matcher/generator classes)
+        // Meta-options like 'blog.permalink' should not invalidate the cache
+        $structuralOptions = array_intersect_key($this->options, [
+            'matcher' => true,
+            'generator' => true,
+            'cache' => true
+        ]);
+
+        // Calculate current cache key and check if it has changed
+        $currentKey = sha1(serialize($this->resource).serialize($structuralOptions));
+        $currentModified = $this->resource->getModified();
+
+        // Reset cache if key or modified time has changed (routes were updated)
+        if (!$this->cache || $this->cache['key'] !== $currentKey || $this->cache['modified'] !== $currentModified) {
+            $this->cache = ['key' => $currentKey, 'modified' => $currentModified];
+            // Invalidate cached matcher/generator/routes when cache key changes
+            $this->matcher = null;
+            $this->generator = null;
+            $this->routes = null;
         }
 
         $file  = sprintf($file, $this->options['cache'], $this->cache['key']);

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.0.46'
+        'version' => '1.0.47'
 
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pagekit/pagekit",
   "title": "Pagekit",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "type": "project",
   "description": "The Pagekit CMS",
   "keywords": [


### PR DESCRIPTION
## Pagekit 1.0.47 - Routing Cache Fix

### 🔧 Fixes

- **Routing cache race condition** - Fixed `ClassNotFoundError` when moving pages via drag & drop
  - Added automatic cache invalidation when routes change (cache key or modified time)
  - Added error handling with fallback to non-cached matcher/generator if cache file is corrupted
  - Fixed cache key calculation to only include structural options (matcher, generator, cache path)
  - Meta-options like `blog.permalink` no longer invalidate routing cache unnecessarily
  - Prevents multiple unnecessary cache files from being created

### Changes

- `app/modules/routing/src/Router.php` - Cache invalidation and error handling improvements
- Version bumped to 1.0.47 in `composer.json` and `app/system/config.php`
- Changelog updated
