### PR TITLE
Template Security Hardening (Step 1.13.5)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,32 +20,47 @@
 
 # Security Headers
 <IfModule mod_headers.c>
-    # HSTS
+    # HSTS - Strict Transport Security
     Header always set Strict-Transport-Security "max-age=31556926; includeSubDomains; preload"
     
-    # X-Content-Type-Options
+    # X-Content-Type-Options - Prevent MIME-type sniffing
     Header always set X-Content-Type-Options "nosniff"
     
-    # X-XSS-Protection
+    # X-XSS-Protection - Enable browser XSS filter (legacy browsers)
     Header always set X-XSS-Protection "1; mode=block"
     
-    # X-Frame-Options
+    # X-Frame-Options - Prevent clickjacking
     Header always set X-Frame-Options "SAMEORIGIN"
     
-    # Referrer Policy
-    Header always set Referrer-Policy "origin-when-cross-origin"
+    # Referrer Policy - Privacy-preserving referrer policy
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
     
-    # Permissions Policy
-    Header always set Permissions-Policy "accelerometer=(), camera=(), microphone=(), geolocation=(), usb=(), gyroscope=(), magnetometer=(), midi=(), ambient-light-sensor=()"
+    # Permissions Policy - Restrict browser features
+    Header always set Permissions-Policy "accelerometer=(), camera=(), microphone=(), geolocation=(), usb=(), gyroscope=(), magnetometer=(), midi=(), ambient-light-sensor=(), autoplay=(), fullscreen=(self), payment=()"
     
-    # Remove X-Powered-By
+    # Remove X-Powered-By - Hide server technology
     Header unset X-Powered-By
     
-    # Cookie Security
+    # Cookie Security - HttpOnly, Secure, SameSite
     Header always edit Set-Cookie ^(.*)$ "$1; HttpOnly; Secure; SameSite=Lax"
     
-    # Content Security Policy for Pagekit (DSGVO-konform)
-    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';"
+    # Content Security Policy - STRICT (Gold Standard)
+    # Since we use JSON data container (no inline scripts), we can be very strict
+    # - script-src: NO 'unsafe-inline', NO 'unsafe-eval'
+    # - style-src: 'unsafe-inline' kept for UIkit inline styles (can be improved later)
+    # - object-src: 'none' - No Flash/plugins
+    # - base-uri: 'self' - Prevent base tag injection
+    # - form-action: 'self' - Forms only submit to same origin
+    Header set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
+    
+    # Cross-Origin-Embedder-Policy - Require CORP for cross-origin resources
+    Header always set Cross-Origin-Embedder-Policy "credentialless"
+    
+    # Cross-Origin-Opener-Policy - Isolate browsing context
+    Header always set Cross-Origin-Opener-Policy "same-origin"
+    
+    # Cross-Origin-Resource-Policy - Restrict resource sharing
+    Header always set Cross-Origin-Resource-Policy "same-origin"
 </IfModule>
 
 # Additional file protection

--- a/.htaccess
+++ b/.htaccess
@@ -46,12 +46,15 @@
     
     # Content Security Policy - STRICT (Gold Standard)
     # Since we use JSON data container (no inline scripts), we can be very strict
-    # - script-src: NO 'unsafe-inline', NO 'unsafe-eval'
+    # - script-src: NO 'unsafe-inline', NO 'unsafe-eval' + Google reCAPTCHA
     # - style-src: 'unsafe-inline' kept for UIkit inline styles (can be improved later)
+    # - img-src: Allow Gravatar and general HTTPS images
+    # - connect-src: Allow external APIs (reCAPTCHA, OpenWeatherMap, Pagekit feeds)
+    # - frame-src: Allow reCAPTCHA iframe
     # - object-src: 'none' - No Flash/plugins
     # - base-uri: 'self' - Prevent base tag injection
     # - form-action: 'self' - Forms only submit to same origin
-    Header set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
+    Header set Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
     
     # Cross-Origin-Embedder-Policy - Require CORP for cross-origin resources
     Header always set Cross-Origin-Embedder-Policy "credentialless"

--- a/.htaccess
+++ b/.htaccess
@@ -56,8 +56,12 @@
     #   3. This would achieve true "Gold Standard" CSP (no unsafe-eval)
     #
     # Current policy:
-    # - script-src: 'self' + 'unsafe-eval' (Vue runtime) + Google reCAPTCHA
-    # - style-src: 'unsafe-inline' kept for UIkit inline styles
+    # - script-src: 'self' + 'unsafe-eval' (Vue runtime) + Google reCAPTCHA + Browser Extensions + LanguageTool hash
+    # - style-src: 'unsafe-inline' kept for UIkit inline styles + Browser Extensions
+    # - img-src: Allow Browser Extensions (for extension icons/widgets)
+    # - font-src: Allow Browser Extensions (for extension fonts)
+    # - connect-src: Allow Browser Extensions (for API calls to extension servers)
+    # - frame-src: Allow Browser Extensions (for extension iframes/widgets)
     # - img-src: Allow Gravatar and general HTTPS images
     # - connect-src: Allow external APIs for Dashboard widgets:
     #   * reCAPTCHA - Form protection
@@ -69,7 +73,10 @@
     # - object-src: 'none' - No Flash/plugins
     # - base-uri: 'self' - Prevent base tag injection
     # - form-action: 'self' - Forms only submit to same origin
-    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com https://maps.googleapis.com https://api.rss2json.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
+    # Note: chrome-extension: and moz-extension: allowed for browser extensions (LanguageTool, password managers, etc.)
+    #       Extensions are user-installed and trusted, so allowing them is safe and improves UX
+    #       LanguageTool inline script hash added to allow extension's injected scripts
+    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' chrome-extension: moz-extension: 'sha256-tq5fHKUNWCWMHbqZJgps3MZdMB//nQ7ZNRkFNo18098=' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline' chrome-extension: moz-extension:; img-src 'self' data: https: blob: chrome-extension: moz-extension:; font-src 'self' data: chrome-extension: moz-extension:; connect-src 'self' chrome-extension: moz-extension: https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com https://maps.googleapis.com https://api.rss2json.com; frame-src 'self' chrome-extension: moz-extension: https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
     
     # Cross-Origin-Opener-Policy - Isolate browsing context (prevents window.opener attacks)
     # This protects against malicious sites that open Pagekit in a popup and try to access the window

--- a/.htaccess
+++ b/.htaccess
@@ -59,21 +59,33 @@
     # - script-src: 'self' + 'unsafe-eval' (Vue runtime) + Google reCAPTCHA
     # - style-src: 'unsafe-inline' kept for UIkit inline styles
     # - img-src: Allow Gravatar and general HTTPS images
-    # - connect-src: Allow external APIs (reCAPTCHA, OpenWeatherMap, Pagekit feeds)
+    # - connect-src: Allow external APIs for Dashboard widgets:
+    #   * reCAPTCHA - Form protection
+    #   * OpenWeatherMap - Weather widget
+    #   * pagekit.com - Update checks, marketplace
+    #   * maps.googleapis.com - Location widget (timezone API)
+    #   * api.rss2json.com - Feed widget (RSS to JSON converter)
     # - frame-src: Allow reCAPTCHA iframe
     # - object-src: 'none' - No Flash/plugins
     # - base-uri: 'self' - Prevent base tag injection
     # - form-action: 'self' - Forms only submit to same origin
-    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
+    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com https://maps.googleapis.com https://api.rss2json.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
     
-    # Cross-Origin-Embedder-Policy - Require CORP for cross-origin resources
-    Header always set Cross-Origin-Embedder-Policy "credentialless"
-    
-    # Cross-Origin-Opener-Policy - Isolate browsing context
+    # Cross-Origin-Opener-Policy - Isolate browsing context (prevents window.opener attacks)
+    # This protects against malicious sites that open Pagekit in a popup and try to access the window
     Header always set Cross-Origin-Opener-Policy "same-origin"
     
-    # Cross-Origin-Resource-Policy - Restrict resource sharing
+    # Cross-Origin-Resource-Policy - Restrict resource sharing (prevents embedding our resources)
+    # This prevents other sites from embedding Pagekit resources (images, scripts) without permission
     Header always set Cross-Origin-Resource-Policy "same-origin"
+    
+    # Cross-Origin-Embedder-Policy: REMOVED
+    # COEP is primarily needed for SharedArrayBuffer (used by WebAssembly, Web Workers)
+    # Pagekit doesn't use these features, so COEP causes more problems than it solves:
+    # - Blocks external resources (reCAPTCHA, OpenWeatherMap) that don't send CORP headers
+    # - Breaks browser extensions (password managers, etc.)
+    # - No security benefit for Pagekit's use case
+    # COOP and CORP provide sufficient protection for Pagekit's needs
 </IfModule>
 
 # Additional file protection

--- a/.htaccess
+++ b/.htaccess
@@ -44,17 +44,27 @@
     # Cookie Security - HttpOnly, Secure, SameSite
     Header always edit Set-Cookie ^(.*)$ "$1; HttpOnly; Secure; SameSite=Lax"
     
-    # Content Security Policy - STRICT (Gold Standard)
-    # Since we use JSON data container (no inline scripts), we can be very strict
-    # - script-src: NO 'unsafe-inline', NO 'unsafe-eval' + Google reCAPTCHA
-    # - style-src: 'unsafe-inline' kept for UIkit inline styles (can be improved later)
+    # Content Security Policy - Secure with Vue.js Runtime Compiler Support
+    # 
+    # IMPORTANT: 'unsafe-eval' is required because Vue.js uses new Function() for
+    # runtime template compilation. Some components (installer-steps, buttons, etc.)
+    # define templates as strings that must be compiled at runtime.
+    #
+    # TODO: FUTURE IMPROVEMENT - Remove 'unsafe-eval' by pre-compiling ALL templates:
+    #   1. Convert all inline `template: '...'` strings to render functions
+    #   2. Use vue-template-compiler during build process
+    #   3. This would achieve true "Gold Standard" CSP (no unsafe-eval)
+    #
+    # Current policy:
+    # - script-src: 'self' + 'unsafe-eval' (Vue runtime) + Google reCAPTCHA
+    # - style-src: 'unsafe-inline' kept for UIkit inline styles
     # - img-src: Allow Gravatar and general HTTPS images
     # - connect-src: Allow external APIs (reCAPTCHA, OpenWeatherMap, Pagekit feeds)
     # - frame-src: Allow reCAPTCHA iframe
     # - object-src: 'none' - No Flash/plugins
     # - base-uri: 'self' - Prevent base tag injection
     # - form-action: 'self' - Forms only submit to same origin
-    Header set Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
+    Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com; frame-src 'self' https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';"
     
     # Cross-Origin-Embedder-Policy - Require CORP for cross-origin resources
     Header always set Cross-Origin-Embedder-Policy "credentialless"

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -1,5 +1,77 @@
 # Changelog 2025
 
+## Pagekit 1.0.47 - Template Security Hardening (January 20, 2026)
+
+### 🔒 Security - Gold Standard CSP Implementation
+
+- **Complete eval() Removal from Template Engines** - Eliminated all `eval()` calls from template rendering
+  - Removed eval() from `app/modules/view/src/PhpEngine.php` (lines 168, 174)
+  - Removed eval() from `app/modules/view/src/Engine/PhpEngine.php` (line 122)
+  - String template execution no longer supported (was dead code path)
+  - All templates must be file-based for security
+
+- **JSON Data Container (Replaces Inline Scripts)** - Industry best practice implementation
+  - `DataHelper` now outputs `<script type="application/json">` instead of inline `<script>var...`
+  - New `config-loader.js` reads JSON and exposes data as global variables
+  - Backward compatible: `$pagekit`, `$debugbar` globals still work
+  - Perfect CSP compliance without `unsafe-inline` in script-src
+
+- **Strict Content Security Policy** - No more `unsafe-inline` or `unsafe-eval`
+  - `script-src 'self'` - No inline scripts, no eval()
+  - `style-src 'self' 'unsafe-inline'` - UIkit requires inline styles (for now)
+  - Added `object-src 'none'` - No Flash/plugins
+  - Added `base-uri 'self'` - Prevent base tag injection
+  - Added `form-action 'self'` - Forms only submit to same origin
+  - Added `frame-ancestors 'self'` - Prevent clickjacking
+
+- **Modern Cross-Origin Security Headers**
+  - `Cross-Origin-Embedder-Policy: credentialless`
+  - `Cross-Origin-Opener-Policy: same-origin`
+  - `Cross-Origin-Resource-Policy: same-origin`
+  - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
+  - Extended `Permissions-Policy` with autoplay, fullscreen, payment
+
+### ✨ New Features
+
+- **config-loader.js** - CSP-compliant configuration reader
+  - Reads JSON from `<script type="application/json">` container
+  - Exposes data as global variables for backward compatibility
+  - No inline JavaScript execution required
+  - Works with strict CSP without exceptions
+
+### 📝 Documentation
+
+- **feature-template-security-hardening.md** - Complete migration guide and documentation
+  - How the JSON data container works
+  - Migration guide for theme/extension developers
+  - Security impact and CSP configuration details
+  - Testing checklist and verification steps
+
+### 🔧 Technical Details
+
+**Files Created:**
+- `app/system/app/lib/config-loader.js`
+- `migration-docs/branches/feature-template-security-hardening.md`
+
+**Files Modified:**
+- `app/modules/view/src/PhpEngine.php` (eval removal)
+- `app/modules/view/src/Engine/PhpEngine.php` (eval removal)
+- `app/modules/view/src/Helper/DataHelper.php` (JSON data container)
+- `app/system/modules/view/index.php` (register config-loader)
+- `.htaccess` (strict CSP and modern headers)
+
+**Breaking Changes (Internal Only):**
+- String template execution no longer supported (was dead code)
+- Inline `<script>` tags with executable JavaScript blocked by CSP
+
+**Backward Compatible:**
+- All existing PHP templates work unchanged
+- Global variables (`$pagekit`, etc.) still accessible
+- Vue.js components work normally
+- Admin interface unchanged
+
+---
+
 ## Pagekit 1.0.46 - Symfony Validator Integration (January 19, 2026)
 
 ### 🚀 Major Changes

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -36,6 +36,7 @@
   - `Cross-Origin-Resource-Policy: same-origin` - Prevents unauthorized embedding of resources
   - `Cross-Origin-Embedder-Policy: REMOVED` - Not needed (Pagekit doesn't use SharedArrayBuffer)
     - COEP caused compatibility issues with external resources (reCAPTCHA, OpenWeatherMap)
+    - COEP breaks browser extensions (password managers, etc.)
     - COOP and CORP provide sufficient protection for Pagekit's use case
   - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
   - Extended `Permissions-Policy` with autoplay, fullscreen, payment

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -23,7 +23,7 @@
   - Added `base-uri 'self'` - Prevent base tag injection
   - Added `form-action 'self'` - Forms only submit to same origin
   - Added `frame-ancestors 'self'` - Prevent clickjacking
-  - External APIs allowed: Google reCAPTCHA, Gravatar, OpenWeatherMap, Pagekit.com
+  - External APIs allowed: Google reCAPTCHA, Gravatar, OpenWeatherMap, Pagekit.com, Google Maps Timezone API, RSS2JSON API
   - **Note:** `unsafe-eval` required because Vue.js 2.x uses `new Function()` for runtime template compilation
 
 - **Inline Script Migration** - All modules migrated to DataHelper
@@ -32,9 +32,11 @@
   - `ScriptHelper`: Inline scripts blocked with warning
 
 - **Modern Cross-Origin Security Headers**
-  - `Cross-Origin-Embedder-Policy: credentialless`
-  - `Cross-Origin-Opener-Policy: same-origin`
-  - `Cross-Origin-Resource-Policy: same-origin`
+  - `Cross-Origin-Opener-Policy: same-origin` - Prevents window.opener attacks
+  - `Cross-Origin-Resource-Policy: same-origin` - Prevents unauthorized embedding of resources
+  - `Cross-Origin-Embedder-Policy: REMOVED` - Not needed (Pagekit doesn't use SharedArrayBuffer)
+    - COEP caused compatibility issues with external resources (reCAPTCHA, OpenWeatherMap)
+    - COOP and CORP provide sufficient protection for Pagekit's use case
   - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
   - Extended `Permissions-Policy` with autoplay, fullscreen, payment
 

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -1,6 +1,6 @@
 # Changelog 2025
 
-## Pagekit 1.0.47 - Template Security Hardening (January 20, 2026)
+## Pagekit 1.0.48 - Template Security Hardening (January 23, 2026)
 
 ### 🔒 Security - Enhanced CSP Implementation
 

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -2,9 +2,9 @@
 
 ## Pagekit 1.0.47 - Template Security Hardening (January 20, 2026)
 
-### 🔒 Security - Gold Standard CSP Implementation
+### 🔒 Security - Enhanced CSP Implementation
 
-- **Complete eval() Removal from Template Engines** - Eliminated all `eval()` calls from template rendering
+- **Complete PHP eval() Removal from Template Engines** - Eliminated all `eval()` calls from template rendering
   - Removed eval() from `app/modules/view/src/PhpEngine.php` (lines 168, 174)
   - Removed eval() from `app/modules/view/src/Engine/PhpEngine.php` (line 122)
   - String template execution no longer supported (was dead code path)
@@ -14,16 +14,17 @@
   - `DataHelper` now outputs `<script type="application/json">` instead of inline `<script>var...`
   - New `config-loader.js` reads JSON and exposes data as global variables
   - Backward compatible: `$pagekit`, `$debugbar` globals still work
-  - Perfect CSP compliance without `unsafe-inline` in script-src
+  - CSP compliance: No `unsafe-inline` required in script-src
 
-- **Strict Content Security Policy** - No more `unsafe-inline` or `unsafe-eval`
-  - `script-src 'self'` - No inline scripts, no eval()
-  - `style-src 'self' 'unsafe-inline'` - UIkit requires inline styles (for now)
+- **Content Security Policy** - Hardened with Vue.js compatibility
+  - `script-src 'self' 'unsafe-eval'` - No inline scripts, but eval needed for Vue.js runtime templates
+  - `style-src 'self' 'unsafe-inline'` - UIkit requires inline styles
   - Added `object-src 'none'` - No Flash/plugins
   - Added `base-uri 'self'` - Prevent base tag injection
   - Added `form-action 'self'` - Forms only submit to same origin
   - Added `frame-ancestors 'self'` - Prevent clickjacking
   - External APIs allowed: Google reCAPTCHA, Gravatar, OpenWeatherMap, Pagekit.com
+  - **Note:** `unsafe-eval` required because Vue.js 2.x uses `new Function()` for runtime template compilation
 
 - **Inline Script Migration** - All modules migrated to DataHelper
   - `CaptchaListener`: `$captcha` now via DataHelper

--- a/CHANGELOG-2025.md
+++ b/CHANGELOG-2025.md
@@ -23,6 +23,12 @@
   - Added `base-uri 'self'` - Prevent base tag injection
   - Added `form-action 'self'` - Forms only submit to same origin
   - Added `frame-ancestors 'self'` - Prevent clickjacking
+  - External APIs allowed: Google reCAPTCHA, Gravatar, OpenWeatherMap, Pagekit.com
+
+- **Inline Script Migration** - All modules migrated to DataHelper
+  - `CaptchaListener`: `$captcha` now via DataHelper
+  - `Editor`: `$editor` now via DataHelper
+  - `ScriptHelper`: Inline scripts blocked with warning
 
 - **Modern Cross-Origin Security Headers**
   - `Cross-Origin-Embedder-Policy: credentialless`

--- a/PROMPT_Vue_Template_Precompilation.md
+++ b/PROMPT_Vue_Template_Precompilation.md
@@ -1,0 +1,358 @@
+# TASK: Vue.js Template Pre-compilation (Gold Standard CSP)
+
+=================================================================================
+CONTEXT: Position in Overall Modernization Plan
+=================================================================================
+
+This is Step 3.2.5 (Template Pre-compilation) of the Pagekit modernization plan.
+- ✅ Previous steps (1.1-1.13.5, 3.1-3.2) should be completed
+- ✅ Step 1.13.5 implemented CSP with `unsafe-eval` (required for Vue runtime templates)
+- ⏳ This step removes `unsafe-eval` by pre-compiling ALL Vue templates
+- 📋 Your task: Pre-compile all Vue template strings to achieve true Gold Standard CSP
+
+Focus: This is ONE focused task. Complete it thoroughly, but don't expand scope.
+
+=================================================================================
+PHILOSOPHY: "Spielwiese" - Doing It Right The First Time
+=================================================================================
+
+WHY REMOVE `unsafe-eval`?
+
+Context:
+- Step 1.13.5 implemented strict CSP but requires `unsafe-eval`
+- Vue.js 2.x uses `new Function()` for runtime template compilation
+- Components with `template: '...'` strings trigger this requirement
+- True Gold Standard CSP = NO `unsafe-inline` AND NO `unsafe-eval`
+
+Current State (from 1.13.5):
+```apache
+script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ ...
+```
+
+Target State (after this step):
+```apache
+script-src 'self' https://www.google.com/recaptcha/ ...
+```
+
+Decision: Pre-compile ALL template strings during build process!
+
+=================================================================================
+AGGRESSIVE MODERNIZATION RULES
+=================================================================================
+
+1. NO COMPATIBILITY LAYERS – do not keep old & new behavior in parallel.
+2. NO ADAPTERS – update all call sites instead of adding wrappers.
+3. BREAKING CHANGES ALLOWED INTERNALLY – as long as public behavior (HTTP/API) stays the same.
+4. DELETE OVER WRAP – if old logic conflicts with the new security model, delete it.
+5. LEGACY HACKS MUST BE MARKED – use `// TODO: Must be refactored later` for unavoidable hacks.
+6. HONEST COMMENTS – Comments must reflect reality. Mark backward compatibility clearly.
+
+=================================================================================
+PROBLEM ANALYSIS
+=================================================================================
+
+Components with runtime template strings that require `unsafe-eval`:
+
+1. **Installer** (`app/installer/app/views/installer.vue`):
+   - `installer-steps` component: `template: '<validation-observer ...>...'`
+   - `buttons` component: `template: '<div class="uk-card-footer">...'`
+
+2. **Admin Components** (search for `template:` in .vue and .js files):
+   ```bash
+   grep -r "template:" app/system/app/ --include="*.vue" --include="*.js"
+   grep -r "template:" app/modules/ --include="*.vue" --include="*.js"
+   grep -r "template:" packages/ --include="*.vue" --include="*.js"
+   ```
+
+3. **Potential locations**:
+   - `app/system/app/components/`
+   - `app/system/modules/*/app/`
+   - `packages/pagekit/*/app/`
+
+=================================================================================
+PHASE 1: Audit All Template Strings
+=================================================================================
+
+1.1. Find ALL components with runtime templates:
+   ```bash
+   # Find template strings in Vue components
+   grep -rn "template:\s*['\`\"]" app/ packages/ --include="*.vue" --include="*.js"
+   
+   # Find template strings in compiled bundles (already compiled = OK)
+   grep -rn "template:\s*['\`\"]" app/*/bundle/ packages/*/bundle/
+   ```
+
+1.2. Categorize findings:
+   - **INLINE**: `template: '...'` inside component definition → MUST FIX
+   - **SFC**: `.vue` files with `<template>` section → OK (webpack compiles these)
+   - **BUNDLE**: Already in bundle/*.js → Check if pre-compiled
+
+1.3. Document all components needing migration:
+   Create checklist of files to modify.
+
+=================================================================================
+PHASE 2: Convert Template Strings to SFC or Render Functions
+=================================================================================
+
+OPTION A: Convert to Single File Components (.vue)
+-------------------------------------------------
+
+For complex templates, extract to separate .vue files:
+
+BEFORE (`installer.vue`):
+```javascript
+components: {
+    'installer-steps': {
+        props: ['current', 'steps'],
+        template: `
+            <validation-observer tag="div" class="tm-slider" v-slot="{ valid, passes }" slim>
+                <template v-for="(step, index) in steps">
+                    <transition name="slide">
+                        <slot :name="step" :step="step" :valid="valid" :passes="passes" v-if="step === current" />
+                    </transition>
+                </template>
+            </validation-observer>`,
+        components: { ValidationObserver }
+    }
+}
+```
+
+AFTER (new file `installer-steps.vue`):
+```vue
+<template>
+    <validation-observer tag="div" class="tm-slider" v-slot="{ valid, passes }" slim>
+        <template v-for="(step, index) in steps">
+            <transition name="slide">
+                <slot :name="step" :step="step" :valid="valid" :passes="passes" v-if="step === current" />
+            </transition>
+        </template>
+    </validation-observer>
+</template>
+
+<script>
+import { ValidationObserver } from '@system/app/components/validation.vue';
+
+export default {
+    name: 'installer-steps',
+    props: ['current', 'steps'],
+    components: { ValidationObserver }
+};
+</script>
+```
+
+Then import in `installer.vue`:
+```javascript
+import InstallerSteps from './installer-steps.vue';
+
+export default {
+    components: {
+        'installer-steps': InstallerSteps,
+        // ...
+    }
+}
+```
+
+OPTION B: Convert to Render Functions
+-------------------------------------
+
+For simple templates, use render functions:
+
+BEFORE:
+```javascript
+buttons: {
+    props: ['prev', 'next'],
+    template: `<div class="uk-card-footer">
+        <a v-if="prev" @click="prev()">Back</a>
+        <a v-if="next" @click="next()">Next</a>
+    </div>`
+}
+```
+
+AFTER:
+```javascript
+buttons: {
+    props: ['prev', 'next'],
+    render(h) {
+        return h('div', { class: 'uk-card-footer' }, [
+            this.prev ? h('a', { on: { click: this.prev } }, 'Back') : null,
+            this.next ? h('a', { on: { click: this.next } }, 'Next') : null
+        ]);
+    }
+}
+```
+
+=================================================================================
+PHASE 3: Webpack Configuration
+=================================================================================
+
+3.1. Ensure vue-loader is configured for template compilation:
+   File: `webpack.config.js`
+   
+   Check that vue-loader compiles templates:
+   ```javascript
+   module: {
+       rules: [
+           {
+               test: /\.vue$/,
+               loader: 'vue-loader',
+               options: {
+                   // Templates should be pre-compiled (default behavior)
+                   compilerOptions: {
+                       // Optional: whitespace handling
+                       preserveWhitespace: false
+                   }
+               }
+           }
+       ]
+   }
+   ```
+
+3.2. Verify bundle output has NO runtime template compilation:
+   After rebuild, check bundles don't contain template strings:
+   ```bash
+   # Should NOT find template strings in bundles
+   grep "template:" app/installer/app/bundle/installer.js | head -5
+   ```
+   
+   Instead, should see `render` functions:
+   ```bash
+   # Should find render functions
+   grep "render:function" app/installer/app/bundle/installer.js | head -5
+   ```
+
+=================================================================================
+PHASE 4: Update CSP (Remove unsafe-eval)
+=================================================================================
+
+4.1. Update .htaccess:
+   File: `.htaccess`
+   
+   BEFORE:
+   ```apache
+   Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google.com/recaptcha/ ...
+   ```
+   
+   AFTER:
+   ```apache
+   Header set Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ ...
+   ```
+
+4.2. Update documentation:
+   - Remove notes about `unsafe-eval` requirement
+   - Document that all templates are pre-compiled
+   - Update `feature-template-security-hardening.md`
+
+=================================================================================
+PHASE 5: Testing
+=================================================================================
+
+5.1. Rebuild all bundles:
+   ```bash
+   npm run compile-js -- --mode=production
+   ```
+
+5.2. Test in browser with strict CSP:
+   ```bash
+   # Start server
+   php -S localhost:8080 index.php
+   
+   # Open browser, check console for CSP violations
+   # Should see ZERO violations!
+   ```
+
+5.3. Test installer (fresh install):
+   ```bash
+   rm config.php pagekit.db
+   # Open http://localhost:8080/installer
+   # Complete installation wizard
+   # All steps should work without CSP errors
+   ```
+
+5.4. Test admin interface:
+   - Login to admin
+   - Check all Vue components render
+   - No console errors
+
+5.5. Run E2E tests:
+   ```bash
+   ./scripts/e2e-reset.sh
+   ./scripts/e2e-start.sh
+   npx playwright test
+   ./scripts/e2e-stop.sh
+   ```
+
+=================================================================================
+SUCCESS CRITERIA (True Gold Standard CSP!)
+=================================================================================
+
+MUST HAVE ✅:
+- ✅ ALL template strings converted to SFC or render functions
+- ✅ NO `template: '...'` strings in component definitions
+- ✅ Bundles contain only pre-compiled render functions
+- ✅ CSP without `unsafe-eval` in script-src
+- ✅ All existing functionality works
+- ✅ Installer wizard works completely
+- ✅ Admin interface works completely
+- ✅ No console errors
+- ✅ No CSP violations
+- ✅ E2E tests pass
+
+MUST NOT ❌:
+- ❌ NO runtime template compilation
+- ❌ NO `unsafe-eval` in CSP
+- ❌ NO breaking changes to user-facing functionality
+
+=================================================================================
+IMPORTANT NOTES FOR AGENT
+=================================================================================
+
+1. **Depends on Vue 2.7 Bridge (Step 3.2)**:
+   Vue 2.7 has better tooling support. Ensure 3.2 is complete first.
+
+2. **Focus on Installer First**:
+   The installer is the most critical and has known template strings.
+   Fix it first, then audit other components.
+
+3. **Use SFC for Complex Templates**:
+   Don't try to convert everything to render functions.
+   SFCs are cleaner and webpack handles compilation.
+
+4. **Test After Each Component**:
+   After converting each component, rebuild and test.
+   Don't batch all changes - find issues early.
+
+5. **CSP Testing Command**:
+   ```bash
+   # Quick CSP test
+   curl -I http://localhost:8080 | grep -i content-security
+   # Should NOT contain 'unsafe-eval'
+   ```
+
+6. **Browser DevTools**:
+   - Open Network tab, reload page
+   - Check Response Headers for CSP
+   - Console should show NO CSP violations
+
+=================================================================================
+REFERENCE: Components Known to Have Template Strings
+=================================================================================
+
+From Step 1.13.5 analysis:
+
+1. `app/installer/app/views/installer.vue`:
+   - `installer-steps` component (line ~458-472)
+   - `buttons` component (line ~435-456)
+
+2. Potentially others (run audit in Phase 1)
+
+=================================================================================
+EXPECTED OUTCOME
+=================================================================================
+
+After completing this task:
+- Pagekit achieves TRUE Gold Standard CSP
+- No `unsafe-inline` (achieved in 1.13.5)
+- No `unsafe-eval` (achieved in this step)
+- Maximum protection against XSS attacks
+- Ready for security audit
+- Modern best practices fully implemented

--- a/app/modules/view/src/Engine/PhpEngine.php
+++ b/app/modules/view/src/Engine/PhpEngine.php
@@ -115,13 +115,11 @@ class PhpEngine implements EngineInterface
         extract($parameters, EXTR_SKIP);
         
         try {
-            // Include template file
+            // Include template file - ONLY file-based templates (security hardening)
             if (isset($storage['path']) && file_exists($storage['path'])) {
                 require $storage['path'];
-            } elseif (isset($storage['content'])) {
-                eval('?>' . $storage['content']);
             } else {
-                throw new \RuntimeException('Invalid storage type');
+                throw new \RuntimeException('Invalid storage: path not found or content not supported');
             }
             
             $content = ob_get_clean();

--- a/app/modules/view/src/Helper/DataHelper.php
+++ b/app/modules/view/src/Helper/DataHelper.php
@@ -4,6 +4,12 @@ namespace Pagekit\View\Helper;
 
 use Pagekit\View\View;
 
+/**
+ * DataHelper - CSP-compliant configuration delivery
+ * 
+ * Uses JSON data container instead of inline scripts for strict CSP compliance.
+ * JavaScript reads configuration from data-attribute (no eval, no inline execution).
+ */
 class DataHelper implements HelperInterface
 {
     protected array $data = [];
@@ -66,17 +72,32 @@ class DataHelper implements HelperInterface
     }
 
     /**
-     * Renders the data tags.
+     * Renders the data as CSP-compliant JSON container.
+     * 
+     * Output: <script id="pagekit-data" type="application/json">{"data":...}</script>
+     * 
+     * Why type="application/json"?
+     * - Browser does NOT execute scripts with type="application/json"
+     * - Perfect for strict CSP (no 'unsafe-inline' needed)
+     * - JavaScript reads data via JSON.parse(element.textContent)
+     * - Industry best practice for passing server data to client
      */
     public function render(): string
     {
-        $output = '';
-
-        foreach ($this->data as $name => $value) {
-            $output .= sprintf("        <script>var %s = %s;</script>\n", $name, json_encode($value, $this->encodingOptions));
+        if (empty($this->data)) {
+            return '';
         }
 
-        return $output;
+        // Build config object with all data
+        $config = [
+            'data' => $this->data
+        ];
+
+        // Encode as JSON (safe for embedding in HTML)
+        $json = json_encode($config, $this->encodingOptions | JSON_UNESCAPED_SLASHES);
+        
+        // Output as JSON script tag (CSP-safe, not executed by browser)
+        return sprintf("        <script id=\"pagekit-data\" type=\"application/json\">%s</script>\n", $json);
     }
 
     /**

--- a/app/modules/view/src/Helper/DataHelper.php
+++ b/app/modules/view/src/Helper/DataHelper.php
@@ -25,13 +25,15 @@ class DataHelper implements HelperInterface
      */
     public function register(View $view): void
     {
-        // Priority 1 = runs AFTER ScriptHelper (priority 5)
-        // This allows modules to add data in 'view.scripts' event
-        // before the JSON is rendered
+        // Priority 10 = runs BEFORE ScriptHelper (priority 5)
+        // JSON data element MUST appear before script tags in HTML
+        // so config-loader.js can read it
+        // 
+        // Modules should add data via 'view.data' event, NOT 'view.scripts'
         $view->on('head', function ($event) use ($view) {
             $view->trigger('data', [$this]);
             $event->addResult($this->render());
-        }, 1);
+        }, 10);
     }
 
     /**

--- a/app/modules/view/src/Helper/DataHelper.php
+++ b/app/modules/view/src/Helper/DataHelper.php
@@ -25,10 +25,13 @@ class DataHelper implements HelperInterface
      */
     public function register(View $view): void
     {
+        // Priority 1 = runs AFTER ScriptHelper (priority 5)
+        // This allows modules to add data in 'view.scripts' event
+        // before the JSON is rendered
         $view->on('head', function ($event) use ($view) {
             $view->trigger('data', [$this]);
             $event->addResult($this->render());
-        }, 10);
+        }, 1);
     }
 
     /**

--- a/app/modules/view/src/Helper/ScriptHelper.php
+++ b/app/modules/view/src/Helper/ScriptHelper.php
@@ -58,6 +58,11 @@ class ScriptHelper implements HelperInterface, \IteratorAggregate
 
     /**
      * Renders the script tags.
+     * 
+     * NOTE: Inline scripts are NO LONGER supported due to strict CSP policy.
+     * Use DataHelper ($view->data('$varname', $value)) for passing data to JavaScript.
+     * 
+     * @see \Pagekit\View\Helper\DataHelper
      */
     public function render(): string
     {
@@ -73,7 +78,15 @@ class ScriptHelper implements HelperInterface, \IteratorAggregate
 
                 $output .= sprintf("        <script src=\"%s\"%s></script>\n", $source, $attributes);
             } elseif ($content = $script->getContent()) {
-                $output .= sprintf("        <script>%s</script>\n", $content);
+                // Inline scripts are blocked by strict CSP (no 'unsafe-inline')
+                // Log warning and skip - use DataHelper instead
+                error_log(sprintf(
+                    '[Pagekit CSP] Inline script "%s" blocked. Use $view->data() instead.',
+                    $script->getName()
+                ));
+                // Output as HTML comment for debugging (CSP-safe)
+                $output .= sprintf("        <!-- CSP: Inline script '%s' blocked. Use DataHelper. -->\n", 
+                    htmlspecialchars($script->getName(), ENT_QUOTES, 'UTF-8'));
             }
         }
 

--- a/app/modules/view/src/PhpEngine.php
+++ b/app/modules/view/src/PhpEngine.php
@@ -156,7 +156,7 @@ class PhpEngine
         extract($parameters, EXTR_SKIP);
         
         try {
-            // Handle different storage types
+            // Handle different storage types - ONLY file-based templates (security hardening)
             if (is_object($template)) {
                 $templatePath = (string) $template;
                 
@@ -164,14 +164,13 @@ class PhpEngine
                 if (file_exists($templatePath)) {
                     require $templatePath;
                 } else {
-                    // Treat as string template
-                    eval('?>' . $templatePath);
+                    throw new \RuntimeException(sprintf('Template file not found: %s', $templatePath));
                 }
             } elseif (is_string($template)) {
                 if (file_exists($template)) {
                     require $template;
                 } else {
-                    eval('?>' . $template);
+                    throw new \RuntimeException(sprintf('Template file not found: %s', $template));
                 }
             }
             

--- a/app/system/app/lib/config-loader.js
+++ b/app/system/app/lib/config-loader.js
@@ -65,16 +65,8 @@
     // Execute IMMEDIATELY and SYNCHRONOUSLY
     // The pagekit-data script tag MUST appear before this script in the HTML
     var success = initConfig();
-    
-    // Debug: Log what was loaded
-    if (console && console.log && window.$pagekit) {
-        console.log('[Pagekit] Config loaded successfully. $pagekit.url =', window.$pagekit.url);
-    }
-    if (console && console.log && window.$installer) {
-        console.log('[Pagekit] Installer config loaded. Locales:', Object.keys(window.$installer.locales || {}).length);
-    }
 
-    // Expose for debugging
+    // Expose for debugging (only the API, no console output)
     window.PagekitConfigLoader = {
         init: initConfig,
         wasSuccessful: function() { return success; }

--- a/app/system/app/lib/config-loader.js
+++ b/app/system/app/lib/config-loader.js
@@ -10,25 +10,26 @@
  * 3. This loader reads the JSON and exposes data as global variables
  * 4. Result: Backward compatible with existing code ($pagekit, etc.)
  * 
+ * IMPORTANT: This script MUST run synchronously before other scripts!
+ * The pagekit-data element must appear BEFORE this script in the HTML.
+ * 
  * @since 1.0.x (Template Security Modernization)
  */
 (function() {
     'use strict';
 
-    var initialized = false;
-
     /**
-     * Initialize configuration from JSON container
+     * Initialize configuration from JSON container - SYNCHRONOUS
      */
     function initConfig() {
-        if (initialized) {
-            return;
-        }
-
         var configElement = document.getElementById('pagekit-data');
         
         if (!configElement) {
-            // No config element yet - might be called too early
+            // This is a problem - the pagekit-data element should exist
+            // It must be rendered BEFORE this script in the HTML
+            if (console && console.warn) {
+                console.warn('[Pagekit] Config element #pagekit-data not found. Make sure it appears before config-loader.js in the HTML.');
+            }
             return false;
         }
 
@@ -42,6 +43,7 @@
             var config = JSON.parse(content);
 
             // Expose data as global variables (backward compatibility)
+            // This MUST happen synchronously before other scripts run!
             if (config.data && typeof config.data === 'object') {
                 Object.keys(config.data).forEach(function(key) {
                     // Set on window object for global access
@@ -49,7 +51,6 @@
                 });
             }
 
-            initialized = true;
             return true;
 
         } catch (e) {
@@ -61,21 +62,22 @@
         }
     }
 
-    // Try immediately (script might be after pagekit-data in DOM)
-    if (!initConfig()) {
-        // If not found, wait for DOM to be ready
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', initConfig);
-        } else {
-            // DOM already loaded, try again with slight delay
-            setTimeout(initConfig, 0);
-        }
+    // Execute IMMEDIATELY and SYNCHRONOUSLY
+    // The pagekit-data script tag MUST appear before this script in the HTML
+    var success = initConfig();
+    
+    // Debug: Log what was loaded
+    if (console && console.log && window.$pagekit) {
+        console.log('[Pagekit] Config loaded successfully. $pagekit.url =', window.$pagekit.url);
+    }
+    if (console && console.log && window.$installer) {
+        console.log('[Pagekit] Installer config loaded. Locales:', Object.keys(window.$installer.locales || {}).length);
     }
 
-    // Also expose for manual re-initialization if needed
+    // Expose for debugging
     window.PagekitConfigLoader = {
         init: initConfig,
-        isInitialized: function() { return initialized; }
+        wasSuccessful: function() { return success; }
     };
 
 })();

--- a/app/system/app/lib/config-loader.js
+++ b/app/system/app/lib/config-loader.js
@@ -15,22 +15,28 @@
 (function() {
     'use strict';
 
+    var initialized = false;
+
     /**
      * Initialize configuration from JSON container
      */
     function initConfig() {
+        if (initialized) {
+            return;
+        }
+
         var configElement = document.getElementById('pagekit-data');
         
         if (!configElement) {
-            // No config element - this is okay for some pages
-            return;
+            // No config element yet - might be called too early
+            return false;
         }
 
         try {
             // Parse JSON content from script tag
             var content = configElement.textContent || configElement.innerText;
             if (!content || content.trim() === '') {
-                return;
+                return false;
             }
 
             var config = JSON.parse(content);
@@ -43,20 +49,33 @@
                 });
             }
 
+            initialized = true;
+            return true;
+
         } catch (e) {
             // Log error but don't break the page
             if (console && console.error) {
                 console.error('[Pagekit] Failed to parse configuration:', e);
             }
+            return false;
         }
     }
 
-    // Execute immediately (this script loads synchronously before other scripts)
-    initConfig();
+    // Try immediately (script might be after pagekit-data in DOM)
+    if (!initConfig()) {
+        // If not found, wait for DOM to be ready
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initConfig);
+        } else {
+            // DOM already loaded, try again with slight delay
+            setTimeout(initConfig, 0);
+        }
+    }
 
     // Also expose for manual re-initialization if needed
     window.PagekitConfigLoader = {
-        init: initConfig
+        init: initConfig,
+        isInitialized: function() { return initialized; }
     };
 
 })();

--- a/app/system/app/lib/config-loader.js
+++ b/app/system/app/lib/config-loader.js
@@ -1,0 +1,62 @@
+/**
+ * Pagekit Config Loader - CSP-Compliant Configuration Reader
+ * 
+ * Reads configuration from JSON script container (no inline scripts needed).
+ * This enables strict Content Security Policy without 'unsafe-inline'.
+ * 
+ * How it works:
+ * 1. Server renders: <script id="pagekit-data" type="application/json">{"data":...}</script>
+ * 2. Browser does NOT execute type="application/json" (it's data, not code)
+ * 3. This loader reads the JSON and exposes data as global variables
+ * 4. Result: Backward compatible with existing code ($pagekit, etc.)
+ * 
+ * @since 1.0.x (Template Security Modernization)
+ */
+(function() {
+    'use strict';
+
+    /**
+     * Initialize configuration from JSON container
+     */
+    function initConfig() {
+        var configElement = document.getElementById('pagekit-data');
+        
+        if (!configElement) {
+            // No config element - this is okay for some pages
+            return;
+        }
+
+        try {
+            // Parse JSON content from script tag
+            var content = configElement.textContent || configElement.innerText;
+            if (!content || content.trim() === '') {
+                return;
+            }
+
+            var config = JSON.parse(content);
+
+            // Expose data as global variables (backward compatibility)
+            if (config.data && typeof config.data === 'object') {
+                Object.keys(config.data).forEach(function(key) {
+                    // Set on window object for global access
+                    window[key] = config.data[key];
+                });
+            }
+
+        } catch (e) {
+            // Log error but don't break the page
+            if (console && console.error) {
+                console.error('[Pagekit] Failed to parse configuration:', e);
+            }
+        }
+    }
+
+    // Execute immediately (this script loads synchronously before other scripts)
+    initConfig();
+
+    // Also expose for manual re-initialization if needed
+    window.PagekitConfigLoader = {
+        init: initConfig
+    };
+
+})();

--- a/app/system/app/vue.js
+++ b/app/system/app/vue.js
@@ -102,9 +102,9 @@ function Install(Vue) {
             options = { url, params };
         }
 
-        // Use Vue.url.options.root (without index.php) for URL generation
-        // Vue.http.options.root (with index.php) is only for API calls
-        Vue.util.extend(options, { root: Vue.url.options.root });
+        // Use Vue.http.options.root which includes /index.php when mod_rewrite is disabled
+        // This ensures URLs work correctly for both mod_rewrite and non-mod_rewrite installations
+        Vue.util.extend(options, { root: Vue.http.options.root });
 
         return this(options);
     };

--- a/app/system/app/vue.js
+++ b/app/system/app/vue.js
@@ -102,7 +102,9 @@ function Install(Vue) {
             options = { url, params };
         }
 
-        Vue.util.extend(options, { root: Vue.http.options.root });
+        // Use Vue.url.options.root (without index.php) for URL generation
+        // Vue.http.options.root (with index.php) is only for API calls
+        Vue.util.extend(options, { root: Vue.url.options.root });
 
         return this(options);
     };

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.0.46'
+        'version' => '1.0.48'
 
     ],
 

--- a/app/system/modules/captcha/src/CaptchaListener.php
+++ b/app/system/modules/captcha/src/CaptchaListener.php
@@ -76,14 +76,13 @@ class CaptchaListener implements EventSubscriberInterface
             return false;
         }, $routes));
 
-        $scripts->register('captcha-config', sprintf(
-            'var $captcha = %s;',
-            json_encode([
-                'grecaptcha' => App::module('system/captcha')->config('recaptcha_sitekey'),
-                'routes' => $routes
-            ])
-        ), [], 'string', ['defer' => true]);
-        $scripts->add('captcha-interceptor', 'system/captcha:app/bundle/captcha-interceptor.js', ['vue', 'captcha-config']);
+        // Use DataHelper for CSP-compliant config delivery (no inline scripts)
+        App::view()->data('$captcha', [
+            'grecaptcha' => App::module('system/captcha')->config('recaptcha_sitekey'),
+            'routes' => $routes
+        ]);
+        
+        $scripts->add('captcha-interceptor', 'system/captcha:app/bundle/captcha-interceptor.js', ['vue', 'pagekit-config']);
     }
 
     public function onRequest($event, $request): void

--- a/app/system/modules/captcha/src/CaptchaListener.php
+++ b/app/system/modules/captcha/src/CaptchaListener.php
@@ -59,7 +59,7 @@ class CaptchaListener implements EventSubscriberInterface
         }
     }
 
-    public function onScripts($event, $scripts): void
+    public function onData($event, $data): void
     {
         if (!App::module('system/captcha')->config('recaptcha_enable')
             || App::user()->isAuthenticated()
@@ -76,12 +76,22 @@ class CaptchaListener implements EventSubscriberInterface
             return false;
         }, $routes));
 
-        // Use DataHelper for CSP-compliant config delivery (no inline scripts)
-        App::view()->data('$captcha', [
+        // Add captcha config to JSON data container
+        $data->add('$captcha', [
             'grecaptcha' => App::module('system/captcha')->config('recaptcha_sitekey'),
             'routes' => $routes
         ]);
-        
+    }
+
+    public function onScripts($event, $scripts): void
+    {
+        if (!App::module('system/captcha')->config('recaptcha_enable')
+            || App::user()->isAuthenticated()
+            || !App::request()->attributes->get('_captcha_routes')
+        ) {
+            return;
+        }
+
         $scripts->add('captcha-interceptor', 'system/captcha:app/bundle/captcha-interceptor.js', ['vue', 'pagekit-config']);
     }
 
@@ -145,6 +155,7 @@ class CaptchaListener implements EventSubscriberInterface
         return [
             'route.configure' => 'onConfigureRoute',
             'request' => ['onRequest', -100],
+            'view.data' => ['onData', 100],
             'view.scripts' => ['onScripts', 100]
         ];
     }

--- a/app/system/modules/captcha/src/CaptchaListener.php
+++ b/app/system/modules/captcha/src/CaptchaListener.php
@@ -85,9 +85,12 @@ class CaptchaListener implements EventSubscriberInterface
 
     public function onScripts($event, $scripts): void
     {
+        // Must match the same conditions as onData() to ensure $captcha exists
+        // when the script runs
         if (!App::module('system/captcha')->config('recaptcha_enable')
             || App::user()->isAuthenticated()
             || !App::request()->attributes->get('_captcha_routes')
+            || !App::module('system/captcha')->config('recaptcha_sitekey')
         ) {
             return;
         }

--- a/app/system/modules/editor/index.php
+++ b/app/system/modules/editor/index.php
@@ -43,11 +43,11 @@ return [
             }
             
             // Add UIkit scripts if configured
-            // Use static paths instead of getting from script manager
+            // Respect debug mode: use non-minified versions when debugging
             if (isset($presets['tinymce_uikit']) && $presets['tinymce_uikit']) {
                 $editor['content_js'] = [
-                    $app['url']->getStatic('app/assets/uikit/dist/js/uikit.min.js'),
-                    $app['url']->getStatic('app/system/assets/js/uikit-icons.min.js')
+                    $app['url']->getStatic('app/assets/uikit/dist/js/' . ($app->debug() ? 'uikit.js' : 'uikit.min.js')),
+                    $app['url']->getStatic('app/system/assets/js/' . ($app->debug() ? 'uikit-icons.js' : 'uikit-icons.min.js'))
                 ];
             }
 

--- a/app/system/modules/editor/index.php
+++ b/app/system/modules/editor/index.php
@@ -25,30 +25,37 @@ return [
 
     'events' => [
 
-        'view.scripts' => function ($event, $scripts) use ($app) {
+        // Add editor data via view.data event
+        'view.data' => function ($event, $data) use ($app) {
             $presets = $this->config('presets');
-            $editorScripts = [];
             $editor = [
                 'root_url' => $app['url']->getStatic(__DIR__),
-                'locale' => $app->module('system/intl')->getLocale()
+                'locale' => $app->module('system/intl')->getLocale(),
+                'content_js' => []
             ];
+            
             if ($css = $app['url']->getStatic('theme:css/theme.css')) {
                 $editor['content_css'] = [ $css ];
             }
-            if (isset($presets['tinymce_uikit']) && $presets['tinymce_uikit'] && ($uikit = $scripts->get('uikit')->getSource())) {
-                $editorScripts[] = $uikit;
-                if ($uikitIcons = $scripts->get('uikit-icons')->getSource()) {
-                    $editorScripts[] = $uikitIcons;
-                }
-            }
+            
             if (isset($presets['tinymce_body_class']) && $presets['tinymce_body_class']) {
                 $editor['body_class'] = 'uk-container';
             }
-            $editor['content_js'] = $editorScripts;
-
-            // Use DataHelper for CSP-compliant config delivery (no inline scripts)
-            $app['view']->data('$editor', $editor);
             
+            // Add UIkit scripts if configured
+            // Use static paths instead of getting from script manager
+            if (isset($presets['tinymce_uikit']) && $presets['tinymce_uikit']) {
+                $editor['content_js'] = [
+                    $app['url']->getStatic('app/assets/uikit/dist/js/uikit.min.js'),
+                    $app['url']->getStatic('app/system/assets/js/uikit-icons.min.js')
+                ];
+            }
+
+            $data->add('$editor', $editor);
+        },
+
+        // Register editor script
+        'view.scripts' => function ($event, $scripts) {
             $scripts->register('editor', 'system/editor:app/bundle/editor.js', ['input-link', 'pagekit-config']);
         }
 

--- a/app/system/modules/editor/index.php
+++ b/app/system/modules/editor/index.php
@@ -46,8 +46,10 @@ return [
             }
             $editor['content_js'] = $editorScripts;
 
-            $scripts->register('editor', 'system/editor:app/bundle/editor.js', ['input-link']);
-            $scripts->register('editor-data', sprintf('var $editor = %s;', json_encode($editor)), ['~editor'], 'string');
+            // Use DataHelper for CSP-compliant config delivery (no inline scripts)
+            $app['view']->data('$editor', $editor);
+            
+            $scripts->register('editor', 'system/editor:app/bundle/editor.js', ['input-link', 'pagekit-config']);
         }
 
     ]

--- a/app/system/modules/finder/app/storage.js
+++ b/app/system/modules/finder/app/storage.js
@@ -1,0 +1,15 @@
+/**
+ * Storage page Vue initialization
+ * 
+ * This file replaces the inline script in storage.php for CSP compliance.
+ * It initializes a Vue instance on the #storage element.
+ */
+
+Vue.ready(function() {
+    if (document.getElementById('storage')) {
+        new Vue({
+            name: 'storage',
+            el: '#storage'
+        });
+    }
+});

--- a/app/system/modules/finder/index.php
+++ b/app/system/modules/finder/index.php
@@ -42,6 +42,8 @@ return [
             $scripts->register('input-image', 'system/finder:app/bundle/input-image.js', ['vue', 'panel-finder']);
             $scripts->register('input-video', 'system/finder:app/bundle/input-video.js', ['vue', 'panel-finder']);
             $scripts->register('link-storage', 'system/finder:app/bundle/link-storage.js', ['~panel-link']);
+            // Storage page Vue initialization (CSP-compliant, no inline script)
+            $scripts->register('storage-init', 'system/finder:app/storage.js', ['vue', 'panel-finder']);
         },
 
         'view.system:modules/settings/views/settings' => function ($event, $view) use ($app) {

--- a/app/system/modules/finder/views/storage.php
+++ b/app/system/modules/finder/views/storage.php
@@ -1,9 +1,5 @@
-<?php $view->script('panel-finder') ?>
+<?php $view->script('storage-init') ?>
 
 <div id="storage" v-cloak>
     <panel-finder root="<?= htmlentities($root) ?>" mode="<?= $mode ?>"></panel-finder>
 </div>
-
-<script>
-    new Vue({name: 'storage', el: '#storage'})
-</script>

--- a/app/system/modules/view/index.php
+++ b/app/system/modules/view/index.php
@@ -52,8 +52,16 @@ return [
         }, 20],
 
         'view.data' => function ($event, $data) use ($app) {
+            // Get base URL - with fallback for installer context
+            $baseUrl = $app['router']->getContext()->getBaseUrl();
+            if (empty($baseUrl)) {
+                // In installer context, router may not be fully configured
+                // Use /index.php as fallback
+                $baseUrl = '/index.php';
+            }
+            
             $data->add('$pagekit', [
-                'url' => $app['router']->getContext()->getBaseUrl(),
+                'url' => $baseUrl,
                 'csrf' => $app['csrf']->generate()
             ]);
         },

--- a/app/system/modules/view/index.php
+++ b/app/system/modules/view/index.php
@@ -52,11 +52,16 @@ return [
         }, 20],
 
         'view.data' => function ($event, $data) use ($app) {
-            // Get base URL - with fallback for installer context
+            // Get base URL from router context
+            // - With mod_rewrite: '' (empty string) - URLs like /admin
+            // - Without mod_rewrite: '/index.php' - URLs like /index.php/admin
             $baseUrl = $app['router']->getContext()->getBaseUrl();
-            if (empty($baseUrl)) {
-                // In installer context, router may not be fully configured
-                // Use /index.php as fallback
+            
+            // Only use fallback in installer context (no config.php yet)
+            // In normal operation, empty baseUrl is correct for mod_rewrite
+            if (empty($baseUrl) && !file_exists($app['path'] . '/config.php')) {
+                // Installer context: router not fully configured
+                // Use /index.php as safe fallback for API calls
                 $baseUrl = '/index.php';
             }
             

--- a/app/system/modules/view/index.php
+++ b/app/system/modules/view/index.php
@@ -65,17 +65,19 @@ return [
 
         'view.scripts' => function ($event, $scripts) use ($app) {
             // Config loader must be first - reads JSON config and exposes global variables
-            // Loaded synchronously (no defer) to ensure $pagekit is available before other scripts
+            // All scripts that might need $pagekit or other globals must depend on this
             $scripts->register('pagekit-config', 'app/system/app/lib/config-loader.js', [], ['defer' => false]);
             
-            $scripts->register('codemirror', 'app/system/modules/editor/app/assets/codemirror/codemirror.min.js');
-            $scripts->register('marked', 'app/system/modules/editor/app/assets/marked/marked.min.js');
+            $scripts->register('codemirror', 'app/system/modules/editor/app/assets/codemirror/codemirror.min.js', ['pagekit-config']);
+            $scripts->register('marked', 'app/system/modules/editor/app/assets/marked/marked.min.js', ['pagekit-config']);
             $scripts->register('lodash', 'app/assets/lodash/dist/'  . ($app->debug() ? 'lodash.js' : 'lodash.min.js'), ['pagekit-config']);
-            $scripts->register('vue', 'app/system/app/bundle/vue.js', ['uikit', 'uikit-icons', 'vue-dist', 'lodash', 'locale']);
-            $scripts->register('vue-dist', 'app/assets/vue/dist/' . ($app->debug() ? 'vue.js' : 'vue.min.js'));
-            $scripts->register('locale', $app->url('@system/intl', ['locale' => $app->module('system/intl')->getLocale(), 'v' => $scripts->getFactory()->getVersion()]), [], ['type' => 'url']);
+            // vue-dist must load AFTER pagekit-config so $pagekit is available
+            $scripts->register('vue-dist', 'app/assets/vue/dist/' . ($app->debug() ? 'vue.js' : 'vue.min.js'), ['pagekit-config']);
+            // locale script returns JS that sets $locale, must load after config
+            $scripts->register('locale', $app->url('@system/intl', ['locale' => $app->module('system/intl')->getLocale(), 'v' => $scripts->getFactory()->getVersion()]), ['pagekit-config'], ['type' => 'url']);
             $scripts->register('uikit', 'app/assets/uikit/dist/js/' . ($app->debug() ? 'uikit.js' : 'uikit.min.js'), ['pagekit-config']);
             $scripts->register('uikit-icons', 'app/system/assets/js/' . ($app->debug() ? 'uikit-icons.js' : 'uikit-icons.min.js'), 'uikit');
+            $scripts->register('vue', 'app/system/app/bundle/vue.js', ['uikit', 'uikit-icons', 'vue-dist', 'lodash', 'locale']);
         }
 
     ]

--- a/app/system/modules/view/index.php
+++ b/app/system/modules/view/index.php
@@ -64,13 +64,17 @@ return [
         },
 
         'view.scripts' => function ($event, $scripts) use ($app) {
+            // Config loader must be first - reads JSON config and exposes global variables
+            // Loaded synchronously (no defer) to ensure $pagekit is available before other scripts
+            $scripts->register('pagekit-config', 'app/system/app/lib/config-loader.js', [], ['defer' => false]);
+            
             $scripts->register('codemirror', 'app/system/modules/editor/app/assets/codemirror/codemirror.min.js');
             $scripts->register('marked', 'app/system/modules/editor/app/assets/marked/marked.min.js');
-            $scripts->register('lodash', 'app/assets/lodash/dist/'  . ($app->debug() ? 'lodash.js' : 'lodash.min.js'));
+            $scripts->register('lodash', 'app/assets/lodash/dist/'  . ($app->debug() ? 'lodash.js' : 'lodash.min.js'), ['pagekit-config']);
             $scripts->register('vue', 'app/system/app/bundle/vue.js', ['uikit', 'uikit-icons', 'vue-dist', 'lodash', 'locale']);
             $scripts->register('vue-dist', 'app/assets/vue/dist/' . ($app->debug() ? 'vue.js' : 'vue.min.js'));
             $scripts->register('locale', $app->url('@system/intl', ['locale' => $app->module('system/intl')->getLocale(), 'v' => $scripts->getFactory()->getVersion()]), [], ['type' => 'url']);
-            $scripts->register('uikit', 'app/assets/uikit/dist/js/' . ($app->debug() ? 'uikit.js' : 'uikit.min.js'));
+            $scripts->register('uikit', 'app/assets/uikit/dist/js/' . ($app->debug() ? 'uikit.js' : 'uikit.min.js'), ['pagekit-config']);
             $scripts->register('uikit-icons', 'app/system/assets/js/' . ($app->debug() ? 'uikit-icons.js' : 'uikit-icons.min.js'), 'uikit');
         }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pagekit/pagekit",
   "title": "Pagekit",
-  "version": "1.0.46",
+  "version": "1.0.48",
   "type": "project",
   "description": "The Pagekit CMS",
   "keywords": [

--- a/migration-docs/branches/feature-template-security-hardening.md
+++ b/migration-docs/branches/feature-template-security-hardening.md
@@ -1,0 +1,195 @@
+# Template Security Hardening (Gold Standard)
+
+## Overview
+
+This feature implements industry-leading security practices for Pagekit's template system, achieving strict Content Security Policy compliance without `unsafe-inline` or `unsafe-eval` in the script-src directive.
+
+**Branch:** `cursor/template-security-modernization-783e`  
+**Status:** Completed  
+**Version:** 1.0.x (Step 1.13.5)
+
+## Changes Made
+
+### Phase 1: eval() Dead Code Removal
+
+**Files Modified:**
+- `app/modules/view/src/PhpEngine.php` (lines 168, 174)
+- `app/modules/view/src/Engine/PhpEngine.php` (line 122)
+
+**What Changed:**
+- Removed `eval('?>' . $template)` string execution fallbacks
+- All templates now must be file-based (more secure)
+- String templates throw `\RuntimeException` instead of executing
+
+**Why:**
+- `eval()` is a critical security vulnerability
+- Never used in production (dead code path)
+- File-based templates are the intended and secure approach
+
+### Phase 2: JSON Data Container (Replaces Inline Scripts)
+
+**Files Modified:**
+- `app/modules/view/src/Helper/DataHelper.php`
+
+**Files Created:**
+- `app/system/app/lib/config-loader.js`
+
+**Files Modified:**
+- `app/system/modules/view/index.php`
+
+**What Changed:**
+
+**Before (vulnerable):**
+```html
+<script>var $pagekit = {"url":"/","csrf":"..."};</script>
+```
+
+**After (CSP-compliant):**
+```html
+<script id="pagekit-data" type="application/json">{"data":{"$pagekit":{"url":"/","csrf":"..."}}}</script>
+```
+
+**How it works:**
+1. Server outputs configuration as JSON in `<script type="application/json">`
+2. Browser does NOT execute `type="application/json"` (it's data, not code)
+3. `config-loader.js` reads JSON and exposes as global variables
+4. Existing code continues to work (`$pagekit` global still accessible)
+
+**Why JSON container instead of data-attributes:**
+- JSON container can hold larger amounts of data
+- No HTML encoding issues
+- Cleaner separation of data and presentation
+- Industry best practice (used by major frameworks)
+
+### Phase 3: Strict Security Headers
+
+**Files Modified:**
+- `.htaccess`
+
+**Content Security Policy (CSP):**
+```apache
+Content-Security-Policy: 
+    default-src 'self'; 
+    script-src 'self';                    # NO unsafe-inline, NO unsafe-eval!
+    style-src 'self' 'unsafe-inline';     # UIkit requires inline styles (for now)
+    img-src 'self' data: https:; 
+    font-src 'self' data:; 
+    connect-src 'self'; 
+    object-src 'none';                    # No Flash/plugins
+    base-uri 'self';                      # Prevent base tag injection
+    form-action 'self';                   # Forms only submit to same origin
+    frame-ancestors 'self';               # Prevent clickjacking
+```
+
+**Additional Headers Added:**
+- `Cross-Origin-Embedder-Policy: credentialless`
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Resource-Policy: same-origin`
+- `Referrer-Policy: strict-origin-when-cross-origin` (upgraded)
+- Extended `Permissions-Policy`
+
+## Backward Compatibility
+
+### Fully Compatible:
+- All existing PHP templates continue to work unchanged
+- Global variables (`$pagekit`, `$debugbar`, etc.) still accessible
+- Vue.js components work normally
+- Admin interface unchanged
+
+### Breaking Changes (Internal Only):
+- String template execution no longer supported (was dead code)
+- Inline `<script>` tags with executable JavaScript will be blocked by CSP
+
+## Testing
+
+### Verification Checklist:
+- [ ] `php pagekit --version` returns version
+- [ ] Homepage loads without errors
+- [ ] Admin login works (`/admin`)
+- [ ] Dashboard loads with Vue.js components
+- [ ] Browser console shows no CSP violations
+- [ ] `$pagekit` global accessible in console
+
+### Browser Console Test:
+```javascript
+// Should output config object
+console.log($pagekit);
+
+// Should show URL and CSRF token
+console.log($pagekit.url, $pagekit.csrf);
+```
+
+### E2E Tests:
+```bash
+./scripts/e2e-reset.sh    # Clean state
+./scripts/e2e-start.sh    # Start test server
+npx playwright test tests/e2e/specs/01-setup/installation.spec.js
+npx playwright test tests/e2e/specs/02-core/authentication.spec.js
+./scripts/e2e-stop.sh     # Stop test server
+```
+
+## Security Impact
+
+### Improvements:
+| Metric | Before | After |
+|--------|--------|-------|
+| CSP Score | Poor (unsafe-inline) | Excellent (strict) |
+| XSS Protection | Vulnerable to inline | Protected |
+| eval() usage | Present (dead code) | Removed |
+| Cross-Origin | Basic | Full protection |
+
+### Remaining TODOs:
+1. **style-src 'unsafe-inline'**: UIkit uses inline styles. Can be addressed in future by:
+   - Using nonce for inline styles
+   - Moving critical styles to external file
+   - Waiting for UIkit update
+
+## Migration Guide
+
+### For Theme Developers:
+If your theme uses inline scripts like:
+```html
+<script>
+    var myConfig = <?= json_encode($config) ?>;
+</script>
+```
+
+Change to:
+```php
+<!-- In PHP template -->
+<?php $view->data('$myConfig', $config); ?>
+
+<!-- In JavaScript (after config-loader.js runs) -->
+<script src="my-script.js"></script>
+```
+
+```javascript
+// my-script.js
+var config = window.$myConfig; // Available from config-loader
+```
+
+### For Extension Developers:
+Use the DataHelper to pass configuration:
+```php
+$app['view']->data('$myExtension', [
+    'setting1' => $value1,
+    'setting2' => $value2,
+]);
+```
+
+## Files Changed Summary
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `app/modules/view/src/PhpEngine.php` | Modified | Remove eval() |
+| `app/modules/view/src/Engine/PhpEngine.php` | Modified | Remove eval() |
+| `app/modules/view/src/Helper/DataHelper.php` | Modified | JSON data container |
+| `app/system/app/lib/config-loader.js` | Created | Read JSON config |
+| `app/system/modules/view/index.php` | Modified | Register config-loader |
+| `.htaccess` | Modified | Strict CSP headers |
+
+## References
+
+- [CSP Evaluator](https://csp-evaluator.withgoogle.com/)
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [OWASP: Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)

--- a/migration-docs/branches/feature-template-security-hardening.md
+++ b/migration-docs/branches/feature-template-security-hardening.md
@@ -84,7 +84,7 @@ Content-Security-Policy:
     style-src 'self' 'unsafe-inline';     # UIkit requires inline styles
     img-src 'self' data: https: blob:;    # Gravatar, uploads
     font-src 'self' data:; 
-    connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com;
+    connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com https://maps.googleapis.com https://api.rss2json.com;
     frame-src 'self' https://www.google.com/recaptcha/;
     object-src 'none';                    # No Flash/plugins
     base-uri 'self';                      # Prevent base tag injection
@@ -99,9 +99,9 @@ Vue.js 2.x uses `new Function()` for compiling template strings at runtime. Comp
 - Various admin components
 
 **Additional Headers Added:**
-- `Cross-Origin-Embedder-Policy: credentialless`
-- `Cross-Origin-Opener-Policy: same-origin`
-- `Cross-Origin-Resource-Policy: same-origin`
+- `Cross-Origin-Opener-Policy: same-origin` - Prevents window.opener attacks
+- `Cross-Origin-Resource-Policy: same-origin` - Prevents unauthorized embedding
+- `Cross-Origin-Embedder-Policy: REMOVED` - Not needed for Pagekit (no SharedArrayBuffer usage)
 - `Referrer-Policy: strict-origin-when-cross-origin` (upgraded)
 - Extended `Permissions-Policy`
 

--- a/migration-docs/branches/feature-template-security-hardening.md
+++ b/migration-docs/branches/feature-template-security-hardening.md
@@ -1,8 +1,10 @@
-# Template Security Hardening (Gold Standard)
+# Template Security Hardening
 
 ## Overview
 
-This feature implements industry-leading security practices for Pagekit's template system, achieving strict Content Security Policy compliance without `unsafe-inline` or `unsafe-eval` in the script-src directive.
+This feature implements enhanced security practices for Pagekit's template system, achieving Content Security Policy compliance without `unsafe-inline` in the script-src directive.
+
+**Note:** `'unsafe-eval'` is currently required because Vue.js 2.x uses `new Function()` for runtime template compilation. Some components (like `installer-steps`, `buttons`) define templates as strings that must be compiled at runtime. See "Future Improvements" for the path to removing this requirement.
 
 **Branch:** `cursor/template-security-modernization-783e`  
 **Status:** Completed  
@@ -69,7 +71,7 @@ The CSP has been configured to allow these external services:
 - Cleaner separation of data and presentation
 - Industry best practice (used by major frameworks)
 
-### Phase 3: Strict Security Headers
+### Phase 3: Security Headers
 
 **Files Modified:**
 - `.htaccess`
@@ -78,16 +80,23 @@ The CSP has been configured to allow these external services:
 ```apache
 Content-Security-Policy: 
     default-src 'self'; 
-    script-src 'self';                    # NO unsafe-inline, NO unsafe-eval!
-    style-src 'self' 'unsafe-inline';     # UIkit requires inline styles (for now)
-    img-src 'self' data: https:; 
+    script-src 'self' 'unsafe-eval';      # unsafe-eval required for Vue.js runtime templates
+    style-src 'self' 'unsafe-inline';     # UIkit requires inline styles
+    img-src 'self' data: https: blob:;    # Gravatar, uploads
     font-src 'self' data:; 
-    connect-src 'self'; 
+    connect-src 'self' https://www.google.com/recaptcha/ https://api.openweathermap.org https://pagekit.com;
+    frame-src 'self' https://www.google.com/recaptcha/;
     object-src 'none';                    # No Flash/plugins
     base-uri 'self';                      # Prevent base tag injection
     form-action 'self';                   # Forms only submit to same origin
     frame-ancestors 'self';               # Prevent clickjacking
 ```
+
+**Why `'unsafe-eval'` is required:**
+Vue.js 2.x uses `new Function()` for compiling template strings at runtime. Components like these use string templates:
+- `installer-steps` in `installer.vue`
+- `buttons` in `installer.vue`  
+- Various admin components
 
 **Additional Headers Added:**
 - `Cross-Origin-Embedder-Policy: credentialless`
@@ -141,16 +150,24 @@ npx playwright test tests/e2e/specs/02-core/authentication.spec.js
 ### Improvements:
 | Metric | Before | After |
 |--------|--------|-------|
-| CSP Score | Poor (unsafe-inline) | Excellent (strict) |
-| XSS Protection | Vulnerable to inline | Protected |
-| eval() usage | Present (dead code) | Removed |
-| Cross-Origin | Basic | Full protection |
+| CSP Script Policy | Poor (unsafe-inline) | Better (no unsafe-inline, but unsafe-eval for Vue) |
+| XSS Protection | Vulnerable to inline scripts | Protected from inline injection |
+| PHP eval() usage | Present (dead code) | Removed |
+| Cross-Origin | Basic | Full protection (COEP, COOP, CORP) |
+| Data Transfer | Inline `<script>var x=...` | JSON data container |
 
-### Remaining TODOs:
-1. **style-src 'unsafe-inline'**: UIkit uses inline styles. Can be addressed in future by:
-   - Using nonce for inline styles
-   - Moving critical styles to external file
-   - Waiting for UIkit update
+### Future Improvements (Remove unsafe-eval and unsafe-inline):
+
+1. **script-src 'unsafe-eval'** - Required for Vue.js runtime template compilation:
+   - Pre-compile ALL template strings during build (webpack/vue-loader)
+   - Convert inline `template: '...'` to render functions
+   - Components to update: `installer-steps`, `buttons`, various admin components
+   - This would achieve true "Gold Standard" CSP
+
+2. **style-src 'unsafe-inline'** - UIkit uses inline styles:
+   - Use nonce-based approach for inline styles
+   - Move critical styles to external file
+   - Wait for UIkit update with CSP support
 
 ## Migration Guide
 

--- a/migration-docs/branches/feature-template-security-hardening.md
+++ b/migration-docs/branches/feature-template-security-hardening.md
@@ -8,6 +8,14 @@ This feature implements industry-leading security practices for Pagekit's templa
 **Status:** Completed  
 **Version:** 1.0.x (Step 1.13.5)
 
+## External APIs Supported
+
+The CSP has been configured to allow these external services:
+- **Google reCAPTCHA**: Script and frame sources for captcha verification
+- **Gravatar**: Images for user avatars (via `img-src https:`)
+- **OpenWeatherMap API**: Weather widget API calls
+- **Pagekit.com**: News feeds and documentation
+
 ## Changes Made
 
 ### Phase 1: eval() Dead Code Removal
@@ -184,9 +192,12 @@ $app['view']->data('$myExtension', [
 | `app/modules/view/src/PhpEngine.php` | Modified | Remove eval() |
 | `app/modules/view/src/Engine/PhpEngine.php` | Modified | Remove eval() |
 | `app/modules/view/src/Helper/DataHelper.php` | Modified | JSON data container |
+| `app/modules/view/src/Helper/ScriptHelper.php` | Modified | Block inline scripts |
 | `app/system/app/lib/config-loader.js` | Created | Read JSON config |
 | `app/system/modules/view/index.php` | Modified | Register config-loader |
-| `.htaccess` | Modified | Strict CSP headers |
+| `app/system/modules/captcha/src/CaptchaListener.php` | Modified | Migrate to DataHelper |
+| `app/system/modules/editor/index.php` | Modified | Migrate to DataHelper |
+| `.htaccess` | Modified | Strict CSP + external APIs |
 
 ## References
 

--- a/migration-docs/pull-requests/PR_template_security_hardening.md
+++ b/migration-docs/pull-requests/PR_template_security_hardening.md
@@ -26,10 +26,14 @@ This PR implements enhanced security for Pagekit's template system, achieving Co
    - `unsafe-eval` required for Vue.js (documented for Step 3.2.5)
 
 4. **Modern Security Headers**
-   - Added `Cross-Origin-Embedder-Policy: credentialless`
-   - Added `Cross-Origin-Opener-Policy: same-origin`
-   - Added `Cross-Origin-Resource-Policy: same-origin`
+   - Added `Cross-Origin-Opener-Policy: same-origin` - Prevents window.opener attacks
+   - Added `Cross-Origin-Resource-Policy: same-origin` - Prevents unauthorized embedding of resources
+   - `Cross-Origin-Embedder-Policy: REMOVED` - Not needed (Pagekit doesn't use SharedArrayBuffer)
+     - COEP caused compatibility issues with external resources (reCAPTCHA, OpenWeatherMap)
+     - COEP breaks browser extensions (password managers, etc.)
+     - COOP and CORP provide sufficient protection for Pagekit's use case
    - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
+   - Extended `Permissions-Policy` with autoplay, fullscreen, payment
 
 5. **Inline Script Migration**
    - Migrated `CaptchaListener` to use DataHelper

--- a/migration-docs/pull-requests/PR_template_security_hardening.md
+++ b/migration-docs/pull-requests/PR_template_security_hardening.md
@@ -1,0 +1,83 @@
+# PR: Template Security Hardening (Step 1.13.5)
+
+## Summary
+
+This PR implements enhanced security for Pagekit's template system, achieving Content Security Policy compliance without `unsafe-inline` in script-src.
+
+**Note:** `'unsafe-eval'` is still required because Vue.js 2.x uses `new Function()` for runtime template compilation. This will be addressed in Step 3.2.5 (Template Pre-compilation).
+
+## Changes
+
+### Security Improvements
+
+1. **PHP eval() Removal**
+   - Removed `eval()` from `app/modules/view/src/PhpEngine.php`
+   - Removed `eval()` from `app/modules/view/src/Engine/PhpEngine.php`
+   - All templates must now be file-based (no string execution)
+
+2. **JSON Data Container (Replaces Inline Scripts)**
+   - `DataHelper` now outputs `<script type="application/json">` instead of `<script>var...`
+   - Created `config-loader.js` to read JSON and expose as global variables
+   - Backward compatible: `$pagekit`, `$debugbar` globals still work
+
+3. **Content Security Policy**
+   - Hardened CSP in `.htaccess`
+   - No `unsafe-inline` in script-src
+   - `unsafe-eval` required for Vue.js (documented for Step 3.2.5)
+
+4. **Modern Security Headers**
+   - Added `Cross-Origin-Embedder-Policy: credentialless`
+   - Added `Cross-Origin-Opener-Policy: same-origin`
+   - Added `Cross-Origin-Resource-Policy: same-origin`
+   - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
+
+5. **Inline Script Migration**
+   - Migrated `CaptchaListener` to use DataHelper
+   - Migrated `Editor` module to use DataHelper
+   - `ScriptHelper` now blocks inline scripts with warning
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `app/modules/view/src/PhpEngine.php` | Remove eval() |
+| `app/modules/view/src/Engine/PhpEngine.php` | Remove eval() |
+| `app/modules/view/src/Helper/DataHelper.php` | JSON data container |
+| `app/modules/view/src/Helper/ScriptHelper.php` | Block inline scripts |
+| `app/system/app/lib/config-loader.js` | NEW - Read JSON config |
+| `app/system/modules/view/index.php` | Register config-loader |
+| `app/system/modules/captcha/src/CaptchaListener.php` | Migrate to DataHelper |
+| `app/system/modules/editor/index.php` | Migrate to DataHelper |
+| `.htaccess` | Strict CSP + security headers |
+
+### Documentation
+
+- Created `migration-docs/branches/feature-template-security-hardening.md`
+- Updated `CHANGELOG-2025.md`
+- Created `PROMPT_Vue_Template_Precompilation.md` for Step 3.2.5
+
+## Testing
+
+- [x] PHP server starts without errors
+- [x] Installer wizard works (fresh install)
+- [x] Admin login works
+- [x] Dashboard loads with Vue components
+- [x] No CSP violations for inline scripts
+- [x] `$pagekit` global accessible in browser console
+
+## Breaking Changes (Internal Only)
+
+- String template execution no longer supported (was dead code)
+- Inline `<script>` tags with executable JavaScript blocked by CSP
+
+## Future Work (Step 3.2.5)
+
+To achieve true Gold Standard CSP (no `unsafe-eval`):
+- Pre-compile all Vue template strings during build
+- Convert `template: '...'` to render functions or SFCs
+- Remove `unsafe-eval` from CSP
+
+## Related
+
+- Closes Step 1.13.5 in modernization plan
+- Prepares for Step 3.2.5 (Template Pre-compilation)


### PR DESCRIPTION
# PR: Template Security Hardening (Step 1.13.5)

## Summary

This PR implements enhanced security for Pagekit''s template system, achieving Content Security Policy compliance without `unsafe-inline` in script-src.

**Note:** `''unsafe-eval''` is still required because Vue.js 2.x uses `new Function()` for runtime template compilation. This will be addressed in Step 3.2.5 (Template Pre-compilation).

## Changes

### Security Improvements

1. **PHP eval() Removal**
   - Removed `eval()` from `app/modules/view/src/PhpEngine.php`
   - Removed `eval()` from `app/modules/view/src/Engine/PhpEngine.php`
   - All templates must now be file-based (no string execution)

2. **JSON Data Container (Replaces Inline Scripts)**
   - `DataHelper` now outputs `<script type=application/json>` instead of `<script>var...`
   - Created `config-loader.js` to read JSON and expose as global variables
   - Backward compatible: `$pagekit`, `$debugbar` globals still work

3. **Content Security Policy**
   - Hardened CSP in `.htaccess`
   - No `unsafe-inline` in script-src
   - `unsafe-eval` required for Vue.js (documented for Step 3.2.5)

4. **Modern Security Headers**
   - Added `Cross-Origin-Opener-Policy: same-origin` - Prevents window.opener attacks
   - Added `Cross-Origin-Resource-Policy: same-origin` - Prevents unauthorized embedding of resources
   - `Cross-Origin-Embedder-Policy: REMOVED` - Not needed (Pagekit doesn''t use SharedArrayBuffer)
     - COEP caused compatibility issues with external resources (reCAPTCHA, OpenWeatherMap)
     - COEP breaks browser extensions (password managers, etc.)
     - COOP and CORP provide sufficient protection for Pagekit''s use case
   - Upgraded `Referrer-Policy` to `strict-origin-when-cross-origin`
   - Extended `Permissions-Policy` with autoplay, fullscreen, payment

5. **Inline Script Migration**
   - Migrated `CaptchaListener` to use DataHelper
   - Migrated `Editor` module to use DataHelper
   - `ScriptHelper` now blocks inline scripts with warning

### Files Changed

| File | Change |
|------|--------|
| `app/modules/view/src/PhpEngine.php` | Remove eval() |
| `app/modules/view/src/Engine/PhpEngine.php` | Remove eval() |
| `app/modules/view/src/Helper/DataHelper.php` | JSON data container |
| `app/modules/view/src/Helper/ScriptHelper.php` | Block inline scripts |
| `app/system/app/lib/config-loader.js` | NEW - Read JSON config |
| `app/system/modules/view/index.php` | Register config-loader |
| `app/system/modules/captcha/src/CaptchaListener.php` | Migrate to DataHelper |
| `app/system/modules/editor/index.php` | Migrate to DataHelper |
| `.htaccess` | Strict CSP + security headers |

### Documentation

- Created `migration-docs/branches/feature-template-security-hardening.md`
- Updated `CHANGELOG-2025.md`
- Created `PROMPT_Vue_Template_Precompilation.md` for Step 3.2.5

## Testing

- [x] PHP server starts without errors
- [x] Installer wizard works (fresh install)
- [x] Admin login works
- [x] Dashboard loads with Vue components
- [x] No CSP violations for inline scripts
- [x] `$pagekit` global accessible in browser console

## Breaking Changes (Internal Only)

- String template execution no longer supported (was dead code)
- Inline `<script>` tags with executable JavaScript blocked by CSP

## Future Work (Step 3.2.5)

To achieve true Gold Standard CSP (no `unsafe-eval`):
- Pre-compile all Vue template strings during build
- Convert `template: ''...''` to render functions or SFCs
- Remove `unsafe-eval` from CSP

## Related

- Closes Step 1.13.5 in modernization plan
- Prepares for Step 3.2.5 (Template Pre-compilation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens client and server rendering security and enforces stricter CSP across the app.
> 
> - Remove `eval()` paths from PHP template engines; only file-based templates are executed
> - Introduce JSON data container via `DataHelper` and new `config-loader.js`; block inline scripts in `ScriptHelper`
> - Migrate `CaptchaListener`, `Editor`, and Finder storage view to use data container and non-inline init
> - Tighten `.htaccess` headers/CSP (no inline scripts; allow required external services; add COOP/CORP; refine policies)
> - Ensure URLs work with/without mod_rewrite; adjust `$pagekit.url` sourcing and Vue URL root handling
> - Bump version to `1.0.48` and add migration/docs (changelog, precompilation prompt)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa41f747a85e792473b2fc63e499e28c908df3fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->