### PR TITLE
Integration of ongoing changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ docker.env
 .cursor/rules/push.mdc
 .cursor/environment.json
 
+# PHPUnit cache
+.phpunit.cache/
+
 # E2E Testing
 .playwright-mcp/**/*
 /test-results/

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,5 +1,22 @@
 # Changelog 2025
 
+## Pagekit 1.1.1 - UrlProvider, Request Attribute & Finder Fixes (January 30, 2026)
+
+### ✨ New Features
+
+- **UrlProvider route() alias** - Added `route()` as alias for `getRoute()` for backward compatibility and clearer API
+- **#[Request] filter options** - Added `options` parameter to `#[Request]` attribute for filter-specific options (e.g. pregreplace pattern)
+
+### 🐛 Bug Fixes
+
+- **FinderController no-op rename** - Fixed error when user saves without changing the file/folder name (source equals target)
+
+### 🔧 Maintenance
+
+- **PHPUnit cache** - Added `.phpunit.cache/` to `.gitignore` to exclude test results from version control
+
+---
+
 ## Pagekit 1.1.0 - Complete PHP 8 Attributes Migration (January 26, 2026)
 
 ### 🚀 Major Changes - BREAKING

--- a/app/modules/application/src/Application/UrlProvider.php
+++ b/app/modules/application/src/Application/UrlProvider.php
@@ -120,6 +120,7 @@ class UrlProvider
 
     /**
      * Gets the URL to a named route.
+     * Alias: route() for backward compatibility and clearer API.
      *
      * @param  string $name
      * @param  mixed  $parameters
@@ -144,6 +145,19 @@ class UrlProvider
         }
 
         return false;
+    }
+
+    /**
+     * Alias for getRoute(). Generates URL to a named route.
+     *
+     * @param  string $name Route name (e.g. '@hello/view/id')
+     * @param  array  $parameters Route parameters
+     * @param  mixed  $referenceType UrlGenerator::ABSOLUTE_PATH (0) or UrlGenerator::ABSOLUTE_URL (1/true)
+     * @return string|false
+     */
+    public function route($name, $parameters = [], $referenceType = UrlGenerator::ABSOLUTE_PATH)
+    {
+        return $this->getRoute($name, $parameters, $referenceType);
     }
 
     /**

--- a/app/modules/routing/src/Attribute/Request.php
+++ b/app/modules/routing/src/Attribute/Request.php
@@ -10,21 +10,25 @@ namespace Pagekit\Routing\Attribute;
  * Usage: #[Request(['param' => 'type'])]
  * Example: #[Request(['id' => 'int', 'filter' => 'array'])]
  * With CSRF: #[Request(['id' => 'int'], csrf: true)]
+ * With filter options (e.g. pregreplace): #[Request(['folders' => 'pregreplace[]'], options: ['folders' => ['pattern' => '/[^a-z0-9_-]/i']])]
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 final class Request
 {
     private array $data;
     private bool $csrf;
+    private array $options;
 
     /**
      * @param array $data Parameter mapping configuration
      * @param bool $csrf Whether to require CSRF validation
+     * @param array $options Filter-specific options, keyed by parameter name (e.g. ['folders' => ['pattern' => '/[^a-z0-9_-]/i']])
      */
-    public function __construct(array $data = [], bool $csrf = false)
+    public function __construct(array $data = [], bool $csrf = false, array $options = [])
     {
         $this->data = $data;
         $this->csrf = $csrf;
+        $this->options = $options;
     }
 
     /**
@@ -41,5 +45,13 @@ final class Request
     public function getCsrf(): bool
     {
         return $this->csrf;
+    }
+
+    /**
+     * Returns filter-specific options keyed by parameter name.
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
     }
 }

--- a/app/modules/routing/src/Event/ConfigureRouteListener.php
+++ b/app/modules/routing/src/Event/ConfigureRouteListener.php
@@ -37,12 +37,13 @@ class ConfigureRouteListener implements EventSubscriberInterface
             $request = $attributes[0]->newInstance();
             $data = $request->getData();
             $csrf = $request->getCsrf();
+            $options = $request->getOptions();
             
             // Only set _request if there's data or csrf is required
             if ($data || $csrf) {
                 // Format expected by ParamFetcherListener and CsrfListener
                 // Only include 'csrf' key when true - isset() returns true for false values
-                $requestConfig = ['value' => $data, 'options' => []];
+                $requestConfig = ['value' => $data, 'options' => $options];
                 if ($csrf) {
                     $requestConfig['csrf'] = true;
                 }

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.1.0'
+        'version' => '1.1.1'
 
     ],
 

--- a/app/system/modules/finder/src/Controller/FinderController.php
+++ b/app/system/modules/finder/src/Controller/FinderController.php
@@ -127,6 +127,11 @@ class FinderController
             return $this->error(__('Invalid path.'));
         }
 
+        // No-op: user saved without changing the name
+        if ($source === $target) {
+            return $this->success(__('Renamed.'));
+        }
+
         if ('w' !== $this->getMode($source) || file_exists($target) || 'w' !== $this->getMode(dirname($target))) {
             throw new ForbiddenException(__('Permission denied.'));
         }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pagekit/pagekit",
   "title": "Pagekit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "project",
   "description": "The Pagekit CMS",
   "keywords": [


### PR DESCRIPTION
Version 1.1.1 - UrlProvider route() alias, #[Request] filter options, FinderController no-op rename fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive, backward-compatible changes; the main behavior impact is limited to routes that start supplying `options` via `#[Request]`, plus a small no-op guard in Finder rename.
> 
> **Overview**
> Bumps the application/package version to **1.1.1** and updates the changelog, plus ignores PHPUnit’s `.phpunit.cache/` directory.
> 
> Adds `UrlProvider::route()` as a simple alias for `getRoute()`.
> 
> Extends `#[Request]` to accept per-parameter filter `options`, and wires those options through `ConfigureRouteListener` into the `_request` route default so `ParamFetcherListener` can apply them.
> 
> Fixes `FinderController::renameAction()` to treat “rename to the same path” as a no-op success instead of erroring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35a464990c03ee8a29b98185610acbf6e74de1ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->