### PR TITLE
docs(1.1.3): GitHub issue-creator skill, workflows, labels and changelog

### DIFF
--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -38,54 +38,54 @@
 - ⏳ : Future work.
 - ⏸️ : Paused (Dependency in future step).
 
-| ID     | Task Name                         | Status | Audit | PR      | Responsibility |
-| :----- | :-------------------------------- | :----- | :---- | :------ | :------------- |
-| 1.1    | Mailer Migration                  | ✅     | 🛡️    | #17     | Audit Passed   |
-| 1.2    | PHPUnit Update                    | ✅     | 🛡️    | #31     | Audit Passed   |
-| 1.3    | Security Patches                  | ✅     | 🛡️    | #30     | Audit Passed   |
-| 1.3.5  | Dependabot Updates                | ✅     | 🛡️    | #32     | Audit Passed   |
-| 1.4    | Safe Minor Updates                | ✅     | 🛡️    | #53     | Audit Passed   |
-| 1.5    | Doctrine DBAL 3.x                 | ✅     | 🛡️    | #54     | Audit Passed   |
-| 1.6    | PSR-11 Container Compatibility    | ✅     | 🛡️    | #55     | Audit Passed   |
-| 1.7    | Event System Compatibility        | ✅     | 🛡️    | #56     | Audit Passed   |
-| 1.8    | Routing System Compatibility      | ✅     | 🛡️    | #57     | Audit Passed   |
-| 1.9    | Symfony 6.4 LTS components        | ✅     | 🛡️    | #60-#61 | Audit Passed   |
-| 1.10   | PSR-6 Cache                       | ✅     | 🛡️    | #62     | Audit Passed   |
-| 1.10.5 | E2E Testing with Playwright       | ✅     | 🛡️    | #67     | Audit Passed   |
-| 1.11   | ORM Modernization                 | ✅     | 🛡️    | #97     | Audit Passed   |
-| 1.12   | DB Migration System               | ✅     | 🛡️    | #107    | Audit Passed   |
-| 1.13   | Validation Update                 | ✅     | 🛡️    | #108    | Audit Passed   |
-| 1.13.5 | Template Security Hardening (CSP) | ⏸️ 80% | 🛡️    | #110    | Audit Passed   |
-| 1.14   | Doctrine Attributes               | ✅     | 🛡️    | #111    | Audit Passed   |
-| 2.0    | Controller Attributes             | ✅     | ⚠️    | #111    | Needs Audit    |
-| 2.0.5  | PSR-11 Container Modernising      | ⏳     | ⏳    | -       | **Next Step**  |
-| 2.1    | Static Analysis & Code Quality    | ⏳     | ⏳    | -       | Phase 2        |
-| 2.1.5  | QueryBuilder API Standardization  | ⏳     | ⏳    | -       | Phase 2        |
-| 2.2    | CI/CD Pipeline                    | ⏳     | ⏳    | -       | Phase 2        |
-| 2.3    | Docker Production                 | ⏳     | ⏳    | -       | Phase 2        |
-| 2.4    | Build Tools                       | ⏳     | ⏳    | -       | Phase 2        |
-| 2.5    | Extension Safety System           | ⏳     | ⏳    | -       | Phase 2        |
-| 3.1    | UIkit Update                      | ⏳     | ⏳    | -       | Phase 3        |
-| 3.2    | Vue 2.7 Bridge                    | ⏳     | ⏳    | -       | Phase 3        |
-| 3.2.5  | Template Pre-compilation (CSP)    | ⏳ 20% | ⏳    | -       | Phase 3        |
-| 3.3    | TypeScript                        | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4    | Vue 3 Migration                   | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4.1  | ↳ vue-resource → axios            | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4.2  | ↳ vue-event-manager → mitt        | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4.3  | ↳ Vue 3 Core + @vue/compat        | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4.4  | ↳ Pinia State Management          | ⏳     | ⏳    | -       | Phase 3        |
-| 3.4.5  | ↳ Deps (intl→Intl, lodash→native) | ⏳     | ⏳    | -       | Phase 3        |
-| 3.5    | Component Library                 | ⏳     | ⏳    | -       | Phase 3        |
-| 4.1    | Basic Security                    | ⏳     | ⏳    | -       | Phase 4        |
-| 4.2    | REST API v2                       | ⏳     | ⏳    | -       | Phase 4        |
-| 4.3    | Performance Optimization          | ⏳     | ⏳    | -       | Phase 4        |
-| 4.4    | Monitoring & Health Checks        | ⏳     | ⏳    | -       | Phase 4        |
-| 5.1    | Modern Block Editor               | ⏳     | ⏳    | -       | Phase 5        |
-| 5.2    | Advanced Security                 | ⏳     | ⏳    | -       | Phase 5        |
-| 5.3    | Advanced Performance              | ⏳     | ⏳    | -       | Phase 5        |
-| 5.4    | Advanced CMS Features             | ⏳     | ⏳    | -       | Phase 5        |
-| 5.5    | Enterprise Features               | ⏳     | ⏳    | -       | Phase 5        |
-| 5.6    | Marketplace & Extensions          | ⏳     | ⏳    | -       | Phase 5        |
+| ID     | Task Name                           | Status | Audit | PR      | Responsibility |
+| :----- | :---------------------------------- | :----- | :---- | :------ | :------------- |
+| 1.1    | Mailer Migration                    | ✅     | 🛡️    | #17     | Audit Passed   |
+| 1.2    | PHPUnit Update                      | ✅     | 🛡️    | #31     | Audit Passed   |
+| 1.3    | Security Patches                    | ✅     | 🛡️    | #30     | Audit Passed   |
+| 1.3.5  | ↳ Dependabot Updates                | ✅     | 🛡️    | #32     | Audit Passed   |
+| 1.4    | Safe Minor Updates                  | ✅     | 🛡️    | #53     | Audit Passed   |
+| 1.5    | Doctrine DBAL 3.x                   | ✅     | 🛡️    | #54     | Audit Passed   |
+| 1.6    | PSR-11 Container Compatibility      | ✅     | 🛡️    | #55     | Audit Passed   |
+| 1.7    | Event System Compatibility          | ✅     | 🛡️    | #56     | Audit Passed   |
+| 1.8    | Routing System Compatibility        | ✅     | 🛡️    | #57     | Audit Passed   |
+| 1.9    | Symfony 6.4 LTS components          | ✅     | 🛡️    | #60-#61 | Audit Passed   |
+| 1.10   | PSR-6 Cache                         | ✅     | 🛡️    | #62     | Audit Passed   |
+| 1.10.5 | ↳ E2E Testing with Playwright       | ✅     | 🛡️    | #67     | Audit Passed   |
+| 1.11   | ORM Modernization                   | ✅     | 🛡️    | #97     | Audit Passed   |
+| 1.12   | DB Migration System                 | ✅     | 🛡️    | #107    | Audit Passed   |
+| 1.13   | Validation Update                   | ✅     | 🛡️    | #108    | Audit Passed   |
+| 1.13.5 | ↳ Template Security Hardening (CSP) | ⏸️ 80% | 🛡️    | #110    | Audit Passed   |
+| 1.14   | Doctrine Attributes                 | ✅     | 🛡️    | #111    | Audit Passed   |
+| 2.0    | Controller Attributes               | ✅     | ⚠️    | #111    | Needs Audit    |
+| 2.0.5  | ↳ PSR-11 Container Modernising      | ⏳     | ⏳    | -       | **Next Step**  |
+| 2.1    | Static Analysis & Code Quality      | ⏳     | ⏳    | -       | Phase 2        |
+| 2.1.5  | ↳ QueryBuilder API Standardization  | ⏳     | ⏳    | -       | Phase 2        |
+| 2.2    | CI/CD Pipeline                      | ⏳     | ⏳    | -       | Phase 2        |
+| 2.3    | Docker Production                   | ⏳     | ⏳    | -       | Phase 2        |
+| 2.4    | Build Tools                         | ⏳     | ⏳    | -       | Phase 2        |
+| 2.5    | Extension Safety System             | ⏳     | ⏳    | -       | Phase 2        |
+| 3.1    | UIkit Update                        | ⏳     | ⏳    | -       | Phase 3        |
+| 3.2    | Vue 2.7 Bridge                      | ⏳     | ⏳    | -       | Phase 3        |
+| 3.2.5  | ↳ Template Pre-compilation (CSP)    | ⏳ 20% | ⏳    | -       | Phase 3        |
+| 3.3    | TypeScript                          | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4    | Vue 3 Migration                     | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4.1  | ↳ vue-resource → axios              | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4.2  | ↳ vue-event-manager → mitt          | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4.3  | ↳ Vue 3 Core + @vue/compat          | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4.4  | ↳ Pinia State Management            | ⏳     | ⏳    | -       | Phase 3        |
+| 3.4.5  | ↳ Deps (intl→Intl, lodash→native)   | ⏳     | ⏳    | -       | Phase 3        |
+| 3.5    | Component Library                   | ⏳     | ⏳    | -       | Phase 3        |
+| 4.1    | Basic Security                      | ⏳     | ⏳    | -       | Phase 4        |
+| 4.2    | REST API v2                         | ⏳     | ⏳    | -       | Phase 4        |
+| 4.3    | Performance Optimization            | ⏳     | ⏳    | -       | Phase 4        |
+| 4.4    | Monitoring & Health Checks          | ⏳     | ⏳    | -       | Phase 4        |
+| 5.1    | Modern Block Editor                 | ⏳     | ⏳    | -       | Phase 5        |
+| 5.2    | Advanced Security                   | ⏳     | ⏳    | -       | Phase 5        |
+| 5.3    | Advanced Performance                | ⏳     | ⏳    | -       | Phase 5        |
+| 5.4    | Advanced CMS Features               | ⏳     | ⏳    | -       | Phase 5        |
+| 5.5    | Enterprise Features                 | ⏳     | ⏳    | -       | Phase 5        |
+| 5.6    | Marketplace & Extensions            | ⏳     | ⏳    | -       | Phase 5        |
 
 ## **🛠️ TECHNICAL STACK REFERENCE**
 

--- a/.cursor/rules/github-labels.mdc
+++ b/.cursor/rules/github-labels.mdc
@@ -1,178 +1,133 @@
 ---
-description: GitHub Labels Guide - Available labels for issues and pull requests in the Pagekit project. Use appropriate labels when creating or updating PRs/issues. Labels help categorize and filter work items. Dependency labels (dependencies, php, javascript, docker, github-actions) are automatically applied by Dependabot. Project labels (frontend, backend, database, module, theme) help identify affected areas. Commit-type labels (breaking-change, security, performance) correlate with Conventional Commits. Standard labels (bug, enhancement, documentation) for general classification. Use multiple labels when appropriate.
+description: 'GitHub Labels Guide (28 labels, synced 2026-02-14). Available labels for issues and PRs in Pagekit. Includes: phase labels (phase-1..phase-5), dependency labels (auto-applied by Dependabot), commit-type labels (breaking-change, security, performance), project area labels (frontend, backend, database, module, theme, migration), and standard GitHub labels. Use when creating or updating PRs/issues.'
 alwaysApply: false
 ---
 
 # GitHub Labels Guide
 
-Available labels for the Pagekit project. Use these when creating or updating issues and pull requests.
+Available labels for the Pagekit project (`Shadesman5/pagekit`).
+Use these when creating or updating issues and pull requests.
+
+**Total: 28 labels** | Last synced with GitHub: 2026-02-14
+
+## Phase Labels (Modernization Roadmap)
+
+Track which modernization phase an issue/PR belongs to. See `.cursor\ROADMAP.md` for phase details.
+
+| Label     | Description                     | Color     |
+| --------- | ------------------------------- | --------- |
+| `phase-1` | Phase 1: Foundation (completed) | `#0E8A16` |
+| `phase-2` | Phase 2: Developer Experience   | `#0052CC` |
+| `phase-3` | Phase 3: Frontend Modernization | `#5319E7` |
+| `phase-4` | Phase 4: Production Ready       | `#D93F0B` |
+| `phase-5` | Phase 5: Innovation and Future  | `#BFDADC` |
 
 ## Dependency Management Labels
 
 These are **automatically applied by Dependabot**:
 
-| Label            | Description               | Color                                                                     | Auto-Applied By             |
-| ---------------- | ------------------------- | ------------------------------------------------------------------------- | --------------------------- |
-| `dependencies`   | Dependency updates        | ![#0366d6](https://via.placeholder.com/15/0366d6/000000?text=+) `#0366d6` | Dependabot (all ecosystems) |
-| `php`            | PHP/Composer dependencies | ![#8892BF](https://via.placeholder.com/15/8892BF/000000?text=+) `#8892BF` | Dependabot (composer)       |
-| `javascript`     | npm/Yarn dependencies     | ![#168700](https://via.placeholder.com/15/168700/000000?text=+) `#168700` | Dependabot (npm)            |
-| `docker`         | Docker container updates  | ![#2496ED](https://via.placeholder.com/15/2496ED/000000?text=+) `#2496ED` | Dependabot (docker)         |
-| `github-actions` | GitHub Actions updates    | ![#2088FF](https://via.placeholder.com/15/2088FF/000000?text=+) `#2088FF` | Dependabot (github-actions) |
+| Label            | Description                                 | Color     | Auto-Applied By             |
+| ---------------- | ------------------------------------------- | --------- | --------------------------- |
+| `dependencies`   | Pull requests that update a dependency file | `#0366d6` | Dependabot (all ecosystems) |
+| `php`            | PHP dependencies and Composer updates       | `#8892BF` | Dependabot (composer)       |
+| `javascript`     | Pull requests that update javascript code   | `#168700` | Dependabot (npm)            |
+| `docker`         | Docker and container updates                | `#2496ED` | Dependabot (docker)         |
+| `github-actions` | GitHub Actions workflow updates             | `#2088FF` | Dependabot (github-actions) |
 
 ## Conventional Commits Related Labels
 
 Correlate with commit types from `conventional-commits.mdc`:
 
-| Label             | Commit Type         | Description                 | Color                                                                     |
-| ----------------- | ------------------- | --------------------------- | ------------------------------------------------------------------------- |
-| `breaking-change` | `feat!:` or `fix!:` | Major version bump required | ![#D93F0B](https://via.placeholder.com/15/D93F0B/000000?text=+) `#D93F0B` |
-| `enhancement`     | `feat:`             | New features                | ![#a2eeef](https://via.placeholder.com/15/a2eeef/000000?text=+) `#a2eeef` |
-| `bug`             | `fix:`              | Bug fixes                   | ![#d73a4a](https://via.placeholder.com/15/d73a4a/000000?text=+) `#d73a4a` |
-| `documentation`   | `docs:`             | Documentation updates       | ![#0075ca](https://via.placeholder.com/15/0075ca/000000?text=+) `#0075ca` |
-| `performance`     | `perf:`             | Performance improvements    | ![#1D76DB](https://via.placeholder.com/15/1D76DB/000000?text=+) `#1D76DB` |
-| `security`        | `fix:` or `feat:`   | Security-related changes    | ![#EE0701](https://via.placeholder.com/15/EE0701/000000?text=+) `#EE0701` |
+| Label             | Commit Type         | Description                                      | Color     |
+| ----------------- | ------------------- | ------------------------------------------------ | --------- |
+| `breaking-change` | `feat!:` or `fix!:` | Breaking changes that require major version bump | `#D93F0B` |
+| `enhancement`     | `feat:`             | New feature or request                           | `#a2eeef` |
+| `bug`             | `fix:`              | Something isn't working                          | `#d73a4a` |
+| `documentation`   | `docs:`             | Improvements or additions to documentation       | `#0075ca` |
+| `performance`     | `perf:`             | Performance improvements                         | `#1D76DB` |
+| `security`        | `fix:` or `feat:`   | Security-related issues and updates              | `#EE0701` |
 
 ## Pagekit Project Area Labels
 
 Identify which part of the system is affected:
 
-| Label       | Description          | Color                                                                     | When to Use                              |
-| ----------- | -------------------- | ------------------------------------------------------------------------- | ---------------------------------------- |
-| `frontend`  | Vue.js/UIkit changes | ![#42B883](https://via.placeholder.com/15/42B883/000000?text=+) `#42B883` | Vue components, UIkit themes, JavaScript |
-| `backend`   | PHP/Server changes   | ![#777BB4](https://via.placeholder.com/15/777BB4/000000?text=+) `#777BB4` | PHP code, Controllers, Services          |
-| `database`  | ORM/Schema changes   | ![#336791](https://via.placeholder.com/15/336791/000000?text=+) `#336791` | Doctrine entities, migrations, queries   |
-| `module`    | Extension system     | ![#BFD4F2](https://via.placeholder.com/15/BFD4F2/000000?text=+) `#BFD4F2` | Module development, extensions           |
-| `theme`     | Theme system         | ![#FFA500](https://via.placeholder.com/15/FFA500/000000?text=+) `#FFA500` | Theme templates, styles                  |
-| `migration` | Modernization tasks  | ![#C5DEF5](https://via.placeholder.com/15/C5DEF5/000000?text=+) `#C5DEF5` | PHP 8.x upgrades, Symfony updates        |
+| Label       | Description                       | Color     | When to Use                              |
+| ----------- | --------------------------------- | --------- | ---------------------------------------- |
+| `frontend`  | Frontend/Vue.js related changes   | `#42B883` | Vue components, UIkit themes, JavaScript |
+| `backend`   | Backend/PHP related changes       | `#777BB4` | PHP code, Controllers, Services          |
+| `database`  | Database and ORM related changes  | `#336791` | Doctrine entities, migrations, queries   |
+| `module`    | Extensions and modules            | `#BFD4F2` | Module development, extensions           |
+| `theme`     | Theme related changes             | `#FFA500` | Theme templates, styles                  |
+| `migration` | Migration and modernization tasks | `#C5DEF5` | PHP 8.x upgrades, Symfony updates        |
 
 ## Standard GitHub Labels
 
 Default labels for general use:
 
-| Label              | Description                | Color                                                                     | When to Use                      |
-| ------------------ | -------------------------- | ------------------------------------------------------------------------- | -------------------------------- |
-| `good first issue` | Good for newcomers         | ![#7057ff](https://via.placeholder.com/15/7057ff/000000?text=+) `#7057ff` | Easy issues for new contributors |
-| `help wanted`      | Extra attention needed     | ![#008672](https://via.placeholder.com/15/008672/000000?text=+) `#008672` | Issues needing community help    |
-| `question`         | Further information needed | ![#d876e3](https://via.placeholder.com/15/d876e3/000000?text=+) `#d876e3` | Clarification requests           |
-| `duplicate`        | Duplicate issue/PR         | ![#cfd3d7](https://via.placeholder.com/15/cfd3d7/000000?text=+) `#cfd3d7` | Already exists elsewhere         |
-| `invalid`          | Invalid issue/PR           | ![#e4e669](https://via.placeholder.com/15/e4e669/000000?text=+) `#e4e669` | Not applicable or incorrect      |
-| `wontfix`          | Won't be addressed         | ![#ffffff](https://via.placeholder.com/15/ffffff/000000?text=+) `#ffffff` | Intentionally not fixing         |
+| Label              | Description                               | Color     | When to Use                      |
+| ------------------ | ----------------------------------------- | --------- | -------------------------------- |
+| `good first issue` | Good for newcomers                        | `#7057ff` | Easy issues for new contributors |
+| `help wanted`      | Extra attention is needed                 | `#008672` | Issues needing community help    |
+| `question`         | Further information is requested          | `#d876e3` | Clarification requests           |
+| `duplicate`        | This issue or pull request already exists | `#cfd3d7` | Already exists elsewhere         |
+| `invalid`          | This doesn't seem right                   | `#e4e669` | Not applicable or incorrect      |
+| `wontfix`          | This will not be worked on                | `#ffffff` | Intentionally not fixing         |
 
 ## Label Usage Guidelines
+
+### Label Combination Formula
+
+Every issue/PR should have: **1 phase label + 1 commit-type label + 1-2 area labels**
+
+### For Modernization Issues
+
+```yaml
+# Phase 2 backend step
+Step 2.0.5: PSR-11 Container Modernisation
+Labels: phase-2, migration, backend
+
+# Phase 3 frontend step
+Step 3.4.1: HTTP Client Migration (vue-resource to axios)
+Labels: phase-3, migration, frontend
+
+# Phase 4 security feature
+Step 4.1: Basic Security and Modern Auth
+Labels: phase-4, enhancement, security, backend
+```
 
 ### For Pull Requests
 
 **Automated (Dependabot PRs)**:
 
-```
+```yaml
 chore(deps): bump symfony/http-foundation from 6.4.1 to 6.4.2
-
 Labels: dependencies, php
 ```
 
-**Manual PRs - Choose by commit type**:
+**Manual PRs - commit type + phase + area**:
 
 ```yaml
 feat(auth): add two-factor authentication
-Labels: enhancement, security, backend
+Labels: phase-4, enhancement, security, backend
 
 fix(blog): sanitize user input in comments
 Labels: bug, security, frontend
 
-refactor(database): modernize query builder
-Labels: migration, database, backend
-
-perf(cache): optimize Redis connection pooling
-Labels: performance, backend
-
-docs(readme): update system requirements
-Labels: documentation
+refactor(container): modernize PSR-11 container
+Labels: phase-2, migration, backend
 ```
 
-**Breaking Changes**:
+### Conventional Commits to Labels Mapping
 
-```yaml
-feat!(api): change authentication response format
-
-Labels: breaking-change, backend, enhancement
-```
-
-### For Issues
-
-**Bug Reports**:
-
-```
-Bug: Login form breaks on Safari
-
-Labels: bug, frontend, help wanted
-```
-
-**Feature Requests**:
-
-```
-Feature: Add markdown editor to blog
-
-Labels: enhancement, frontend, module
-```
-
-**Security Issues**:
-
-```
-Security: XSS vulnerability in comment system
-
-Labels: security, bug, frontend
-```
-
-### Multiple Labels
-
-Use **multiple labels** when appropriate:
-
-```yaml
-# Vue.js performance optimization
-Labels: performance, frontend
-
-# Database security fix
-Labels: security, bug, database, backend
-
-# Breaking change in module API
-Labels: breaking-change, module, backend, migration
-
-# Frontend bug that needs help
-Labels: bug, frontend, help wanted, good first issue
-```
-
-## Integration with Workflows
-
-### Conventional Commits → Labels Mapping
-
-When creating commits, think about corresponding labels:
-
-| Commit Type         | Suggested Labels                            |
-| ------------------- | ------------------------------------------- |
-| `feat:`             | `enhancement` + area label                  |
-| `fix:`              | `bug` + area label                          |
-| `feat!:` or `fix!:` | `breaking-change` + area label              |
-| `docs:`             | `documentation`                             |
-| `perf:`             | `performance` + area label                  |
-| `refactor:`         | `migration` (if modernization) + area label |
-| `chore(deps):`      | Auto-labeled by Dependabot                  |
-
-### Feature Branch Workflow
-
-When working with `feature-branch.mdc`:
-
-1. **Feature Start**: Tag issues with appropriate labels
-2. **Development**: PRs inherit labels from linked issues
-3. **Completion**: Verify labels match commit types
-
-### Push Workflow
-
-When using `push.mdc`:
-
-1. Commits are created with Conventional Commits format
-2. PR is auto-created with a descriptive and smart title
-3. **Manually add appropriate labels** to the PR based on commit types
-4. Labels help with changelog categorization
+| Commit Type         | Suggested Labels                                    |
+| ------------------- | --------------------------------------------------- |
+| `feat:`             | `enhancement` + phase label + area label            |
+| `fix:`              | `bug` + area label (+ phase label if modernization) |
+| `feat!:` or `fix!:` | `breaking-change` + area label                      |
+| `docs:`             | `documentation`                                     |
+| `perf:`             | `performance` + area label                          |
+| `refactor:`         | `migration` (if modernization) + phase + area label |
+| `chore(deps):`      | Auto-labeled by Dependabot                          |
 
 ## Quick Reference
 
@@ -180,6 +135,8 @@ When using `push.mdc`:
 
 | What You're Doing             | Labels to Use                          |
 | ----------------------------- | -------------------------------------- |
+| Phase 2 modernization step    | `phase-2`, `migration`, `backend`      |
+| Phase 3 frontend migration    | `phase-3`, `migration`, `frontend`     |
 | Fixing a bug in Vue component | `bug`, `frontend`                      |
 | Adding new module feature     | `enhancement`, `module`, `backend`     |
 | Upgrading Symfony components  | `migration`, `dependencies`, `backend` |
@@ -187,66 +144,23 @@ When using `push.mdc`:
 | Security patch                | `security`, `bug`, appropriate area    |
 | Breaking API change           | `breaking-change`, appropriate area    |
 | Documentation update          | `documentation`                        |
-| Theme styling fix             | `bug`, `theme`, `frontend`             |
 
-### By Severity/Priority
+## Managing Labels via CLI
 
-- **Critical**: `security`, `bug`, `breaking-change`
-- **Important**: `bug`, `enhancement`, `performance`
-- **Minor**: `documentation`, `theme`
-- **Community**: `help wanted`, `good first issue`
+Labels can be created, edited, and deleted using `gh` CLI from Cursor:
 
-## Tips
+```bash
+# List all labels
+gh label list --repo Shadesman5/pagekit
 
-1. **Be specific**: Use multiple labels to clearly categorize
-2. **Follow conventions**: Match labels with commit types
-3. **Think about changelog**: Labels help generate release notes
-4. **Consider audience**: Use `good first issue` for newcomers
-5. **Security first**: Always tag security issues appropriately
-6. **Breaking changes**: Don't forget the `breaking-change` label for major version bumps
+# Create a new label
+gh label create "label-name" --description "Description" --color "HEX" --repo Shadesman5/pagekit
 
-## Examples from Pagekit Development
+# Edit a label
+gh label edit "label-name" --description "New description" --repo Shadesman5/pagekit
 
-### Recent Migration Work
-
-```yaml
-PR: "Upgrade to Symfony 6.4 components"
-Commit: chore(deps): upgrade symfony components to 6.4
-Labels: dependencies, php, backend, migration
+# Delete a label
+gh label delete "label-name" --repo Shadesman5/pagekit --yes
 ```
 
-### Frontend Enhancement
-
-```yaml
-PR: "Add drag-and-drop file upload to media manager"
-Commit: feat(media): add drag-and-drop upload support
-Labels: enhancement, frontend, module
-```
-
-### Security Fix
-
-```yaml
-PR: "Sanitize user input in blog comments"
-Commit: fix(blog): prevent XSS in comment rendering
-Labels: security, bug, frontend, module
-```
-
-### Performance Improvement
-
-```yaml
-PR: "Optimize Vue component rendering"
-Commit: perf(frontend): lazy load Vue components
-Labels: performance, frontend
-```
-
-### Breaking Change
-
-```yaml
-PR: "Drop PHP 7.4 support, require PHP 8.2+"
-Commit: feat!: drop PHP 7.4 support
-Labels: breaking-change, migration, backend
-```
-
----
-
-**Remember**: Labels are tools for organization and communication. Use them consistently to help your team and future you understand the project's evolution! 🏷️
+After any label changes, update this file to keep it in sync with GitHub.

--- a/.cursor/skills/github-issue-creator/SKILL.md
+++ b/.cursor/skills/github-issue-creator/SKILL.md
@@ -239,15 +239,14 @@ rm temp-issue-body.md
 6. For steps with sub-steps: create parent first, then sub-issues, then link
 7. Report summary with issue numbers and URLs
 
-## Adding to GitHub Project (optional)
+## GitHub Project Integration (fully automatic)
 
-Project items are auto-added via the "Auto-add to project" workflow in GitHub Project settings.
-The Phase field is auto-set via `.github/workflows/project-auto-phase.yml` based on `phase-X` labels.
+No manual project management needed. Two automations handle everything:
 
-Manual add if needed:
-```bash
-gh project item-add 2 --owner Shadesman5 --url ISSUE_URL
-```
+1. **"Auto-add to project"** (built-in Project workflow) — adds every new issue to the board with Status: "Todo"
+2. **`project-auto-phase.yml`** (GitHub Action) — reads the `phase-X` label and sets the Phase field automatically (with retry for race conditions)
+
+The `phase-X` label on the issue is the only input needed. Everything else is derived from it.
 
 ## Check Before Creating
 

--- a/.cursor/skills/github-issue-creator/SKILL.md
+++ b/.cursor/skills/github-issue-creator/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: github-issue-creator
+description: Creates GitHub issues on Shadesman5/pagekit with correct labels, milestones, PR linking, and parent/sub-issue relationships. Use when any agent (architect, refactorer, verifier, tester, or user) needs to create a GitHub issue — whether from a TODO/phase markdown file, a discovered bug, a missing ROADMAP step, deferred work, or any other reason.
+---
+
+# GitHub Issue Creator
+
+Universal skill for creating GitHub issues on `Shadesman5/pagekit`.
+Any agent or user can trigger this.
+
+## When to Use
+
+- **User asks** to create issues from a markdown/TODO file (batch mode)
+- **User asks** to create a single issue for any reason
+- **Tester** discovers a bug or regression that needs its own issue
+- **Verifier** finds legacy debt or compliance gap needing a future fix
+- **Architect** identifies a missing ROADMAP sub-step (e.g. 2.0.5b)
+- **Refactorer** encounters an out-of-scope problem during work
+
+## Prerequisites
+
+- `gh` CLI authenticated (`gh auth status`)
+- Issues enabled on repo
+- For project operations: `gh auth refresh -s read:project,project` (adds project scope)
+
+## What Gets Set on Every Issue
+
+Every issue should have as many of these as applicable:
+
+| Field | How to set | When |
+|-------|-----------|------|
+| **Title** | `--title` | Always |
+| **Labels** | `--label "phase-2,migration,backend"` | Always (see formula below) |
+| **Milestone** | `--milestone "Phase 2: Developer Experience"` | Always for ROADMAP steps |
+| **Body** | `--body-file` | Always |
+| **PR Link** | `Closes #17` or `Related: #17` in body | When a PR exists or will exist |
+| **Parent Issue** | Add as sub-issue after creation | When step has sub-steps in ROADMAP |
+| **Assignee** | `--assignee Shadesman5` | Optional |
+
+## Label Formula
+
+**1 phase label + 1 type label + 1-2 area labels**
+
+Read `.cursor/rules/github-labels.mdc` for full list.
+
+### Phase
+
+| Step range | Label |
+|------------|-------|
+| 0.x – 1.x | `phase-1` |
+| 2.x        | `phase-2` |
+| 3.x        | `phase-3` |
+| 4.x        | `phase-4` |
+| 5.x        | `phase-5` |
+| Unknown    | Infer from context or ask user |
+
+### Type (pick one)
+
+| Situation | Label |
+|-----------|-------|
+| Modernization / refactoring | `migration` |
+| New feature | `enhancement` |
+| Bug | `bug` |
+| Performance | `performance` |
+| Security | `security` |
+| Documentation | `documentation` |
+
+### Area (pick one or more)
+
+| Keywords in title/description | Label |
+|-------------------------------|-------|
+| PHP, Controller, Service, Container, PSR, Symfony, ORM, Auth, API, Docker, CI/CD | `backend` |
+| Vue, UIkit, JavaScript, TypeScript, Component, CSS, Webpack | `frontend` |
+| Database, DBAL, Schema, Query | `database` |
+| Extension, Module, Plugin | `module` |
+| Theme, Template styling | `theme` |
+
+## Milestones
+
+| Phase | Milestone name |
+|-------|---------------|
+| Phase 1 | `Phase 1: Foundation` |
+| Phase 2 | `Phase 2: Developer Experience` |
+| Phase 3 | `Phase 3: Frontend Modernization` |
+| Phase 4 | `Phase 4: Production Ready` |
+| Phase 5 | `Phase 5: Advanced Features` |
+
+No version numbers — versioning is dynamic (see `version-bump` SKILL).
+
+If a milestone doesn't exist yet:
+```bash
+echo '{"title":"Phase X: Name","state":"open","description":"..."}' | gh api repos/Shadesman5/pagekit/milestones --input -
+```
+
+## Issue Body Template
+
+```markdown
+## Goal
+
+[One clear sentence describing what needs to happen]
+
+## Context
+
+- **ROADMAP Step**: [X.Y]
+- **Phase**: [Phase number and name]
+- **Discovered by**: [User / Architect / Tester / Verifier / Refactorer]
+- **Depends on**: [Previous step or "None"]
+- **Branch**: `[branch-name]` (if known, otherwise omit)
+
+## Tasks
+
+- [ ] [Concrete task 1]
+- [ ] [Concrete task 2]
+- [ ] Write/update tests
+- [ ] Update documentation if needed
+
+## Acceptance Criteria
+
+- [ ] All existing tests pass
+- [ ] No regressions
+- [ ] [Step-specific criteria]
+```
+
+**Body rules:**
+- Do NOT link to agent-prompt files
+- Do NOT include internal agent workflow details
+- Keep readable for any developer (human or agent)
+- Reference ROADMAP step IDs when applicable
+- Link related PRs in the "Related" section
+
+## PR Linking
+
+### Existing PR (already merged)
+
+If a PR already exists for the step, add it to the body:
+```markdown
+## Related
+
+- PR: #17
+```
+
+### Future PR (will be created)
+
+When creating a PR later, include in the PR body:
+```markdown
+Closes #42
+```
+This auto-closes the issue when the PR merges.
+
+### Multiple PRs
+
+Some steps may have multiple PRs:
+```markdown
+## Related
+
+- PR: #60 (Symfony HttpFoundation upgrade)
+- PR: #61 (Symfony HttpKernel upgrade)
+```
+
+## Parent Issues and Sub-Issues
+
+### When to use
+
+Use parent/sub-issue structure when a ROADMAP step has sub-steps:
+- Step 3.4 (Vue 3 Migration) → parent issue
+  - Step 3.4.1 (vue-resource → axios) → sub-issue
+  - Step 3.4.2 (vue-event-manager → mitt) → sub-issue
+  - Step 3.4.3 (Vue 3 Core) → sub-issue
+
+### How to create
+
+1. Create the **parent issue** first (e.g. "Step 3.4: Vue 3 Migration")
+2. Create each **sub-issue** (e.g. "Step 3.4.1: HTTP Client Migration")
+3. Link sub-issues to parent using the GitHub CLI:
+
+```bash
+# Add sub-issue to parent
+gh issue edit PARENT_NUMBER --repo Shadesman5/pagekit --add-sub-issue SUB_ISSUE_URL
+```
+
+Or mention in the parent body:
+```markdown
+## Sub-Issues
+
+- [ ] #43 Step 3.4.1: vue-resource → axios
+- [ ] #44 Step 3.4.2: vue-event-manager → mitt
+- [ ] #45 Step 3.4.3: Vue 3 Core + @vue/compat
+```
+
+The "Sub-issues progress" field in the GitHub Project then shows progress (e.g. 2/5).
+
+### When NOT to use
+
+Steps without sub-steps (e.g. Step 1.1 Mailer Migration, Step 2.1 Static Analysis) are standalone issues — no parent needed.
+
+## Creating an Issue
+
+```bash
+# Write body to temp file
+cat > temp-issue-body.md << 'EOF'
+## Goal
+Migrate Swift Mailer to Symfony Mailer 5.4.
+
+## Context
+- **ROADMAP Step**: 1.1
+- **Phase**: Phase 1 - Foundation
+
+## Tasks
+- [ ] Replace Swift Mailer with Symfony Mailer
+- [ ] Update transport configuration
+- [ ] Write unit and integration tests
+
+## Acceptance Criteria
+- [ ] Email sending works (SMTP + Sendmail)
+- [ ] 42 tests passing
+
+## Related
+- PR: #17
+EOF
+
+# Create issue
+gh issue create --repo Shadesman5/pagekit \
+  --title "Step 1.1: Mailer Migration" \
+  --body-file "temp-issue-body.md" \
+  --label "phase-1,migration,backend" \
+  --milestone "Phase 1: Foundation"
+
+# Clean up
+rm temp-issue-body.md
+```
+
+## Batch Mode
+
+1. Read source file (e.g. `MODERNISING_PAGEKIT_TODO_LIST.md` or `ROADMAP.md`)
+2. Parse each step: number, title, status, sub-steps, related PR
+3. **Skip** `✅` completed steps unless user says otherwise
+4. **Show preview table** to user before creating
+5. Create issues one by one
+6. For steps with sub-steps: create parent first, then sub-issues, then link
+7. Report summary with issue numbers and URLs
+
+## Adding to GitHub Project (optional)
+
+Project items are auto-added via the "Auto-add to project" workflow in GitHub Project settings.
+The Phase field is auto-set via `.github/workflows/project-auto-phase.yml` based on `phase-X` labels.
+
+Manual add if needed:
+```bash
+gh project item-add 2 --owner Shadesman5 --url ISSUE_URL
+```
+
+## Check Before Creating
+
+Always verify the issue doesn't already exist:
+```bash
+gh issue list --repo Shadesman5/pagekit --search "Step 2.0.5" --json number,title --limit 5
+```
+
+## Sub-Agent Examples
+
+**Tester finds regression:**
+> Creating issue: "Bug: UserController loginAction missing CSRF validation"
+> Labels: phase-2, bug, security, backend. Milestone: Phase 2.
+
+**Verifier finds legacy debt:**
+> Creating issue: "Step 2.0.5b: Config service still uses array-access"
+> Labels: phase-2, migration, backend. Milestone: Phase 2. Parent: Step 2.0.5 issue.
+
+**Architect adds missing sub-step:**
+> Creating issue: "Step 2.0.5b: Config Service Modernization"
+> Labels: phase-2, migration, backend. Sub-issue of Step 2.0.5.

--- a/.github/workflows/project-auto-phase.yml
+++ b/.github/workflows/project-auto-phase.yml
@@ -77,31 +77,43 @@ jobs:
               }
             `;
 
+            // Find the issue item in the project, with retry for race condition
             let itemId = null;
-            let cursor = null;
+            const maxRetries = 3;
+            const retryDelays = [5000, 10000, 15000]; // 5s, 10s, 15s
 
-            // Paginate through project items to find the issue
-            while (true) {
-              const result = await github.graphql(findItem, {
-                projectId,
-                cursor
-              });
+            for (let attempt = 0; attempt <= maxRetries; attempt++) {
+              let cursor = null;
 
-              const items = result.node.items.nodes;
-              const match = items.find(item => item.content && item.content.id === issueNodeId);
+              while (true) {
+                const result = await github.graphql(findItem, {
+                  projectId,
+                  cursor
+                });
 
-              if (match) {
-                itemId = match.id;
-                break;
+                const items = result.node.items.nodes;
+                const match = items.find(item => item.content && item.content.id === issueNodeId);
+
+                if (match) {
+                  itemId = match.id;
+                  break;
+                }
+
+                if (!result.node.items.pageInfo.hasNextPage) break;
+                cursor = result.node.items.pageInfo.endCursor;
               }
 
-              if (!result.node.items.pageInfo.hasNextPage) break;
-              cursor = result.node.items.pageInfo.endCursor;
+              if (itemId) break;
+
+              if (attempt < maxRetries) {
+                const delay = retryDelays[attempt];
+                console.log(`Issue not yet in project (attempt ${attempt + 1}/${maxRetries + 1}). Waiting ${delay / 1000}s for auto-add...`);
+                await new Promise(resolve => setTimeout(resolve, delay));
+              }
             }
 
             if (!itemId) {
-              console.log('Issue not found in project. It may not have been added yet.');
-              console.log('The "Auto-add to project" workflow should add it first.');
+              core.setFailed(`Issue #${context.payload.issue.number} not found in project after ${maxRetries + 1} attempts. Check that "Auto-add to project" workflow is enabled in project settings.`);
               return;
             }
 

--- a/.github/workflows/project-auto-phase.yml
+++ b/.github/workflows/project-auto-phase.yml
@@ -1,0 +1,131 @@
+# Sets the "Phase" custom field in the GitHub Project based on phase-X labels.
+# Triggers when an issue is labeled with phase-1, phase-2, phase-3, phase-4, or phase-5.
+#
+# Requires:
+#   Secret:   PROJECT_TOKEN          - PAT with project scope
+#   Variable: PROJECT_ID             - GraphQL node ID of the project
+#   Variable: PROJECT_PHASE_FIELD_ID - GraphQL node ID of the Phase field
+#   Variable: PROJECT_PHASE_OPTIONS  - JSON map: {"Phase 1":"id","Phase 2":"id",...}
+
+name: Auto-set Phase in Project
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  set-phase:
+    runs-on: ubuntu-latest
+    # Only run if the added label starts with "phase-"
+    if: startsWith(github.event.label.name, 'phase-')
+    steps:
+      - name: Set Phase field in project
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const label = context.payload.label.name;
+            const issueNodeId = context.payload.issue.node_id;
+
+            // Map label to Phase option name
+            const phaseMap = {
+              'phase-1': 'Phase 1',
+              'phase-2': 'Phase 2',
+              'phase-3': 'Phase 3',
+              'phase-4': 'Phase 4',
+              'phase-5': 'Phase 5'
+            };
+
+            const phaseName = phaseMap[label];
+            if (!phaseName) {
+              console.log(`Unknown phase label: ${label}`);
+              return;
+            }
+
+            // IDs from repository variables
+            const projectId = '${{ vars.PROJECT_ID }}';
+            const fieldId = '${{ vars.PROJECT_PHASE_FIELD_ID }}';
+            const phaseOptions = JSON.parse('${{ vars.PROJECT_PHASE_OPTIONS }}');
+
+            const optionId = phaseOptions[phaseName];
+            if (!optionId) {
+              console.log(`No option ID found for "${phaseName}". Check PROJECT_PHASE_OPTIONS variable.`);
+              return;
+            }
+
+            // Find the issue item in the project
+            const findItem = `
+              query($projectId: ID!, $cursor: String) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100, after: $cursor) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            id
+                          }
+                        }
+                      }
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            let itemId = null;
+            let cursor = null;
+
+            // Paginate through project items to find the issue
+            while (true) {
+              const result = await github.graphql(findItem, {
+                projectId,
+                cursor
+              });
+
+              const items = result.node.items.nodes;
+              const match = items.find(item => item.content && item.content.id === issueNodeId);
+
+              if (match) {
+                itemId = match.id;
+                break;
+              }
+
+              if (!result.node.items.pageInfo.hasNextPage) break;
+              cursor = result.node.items.pageInfo.endCursor;
+            }
+
+            if (!itemId) {
+              console.log('Issue not found in project. It may not have been added yet.');
+              console.log('The "Auto-add to project" workflow should add it first.');
+              return;
+            }
+
+            // Set the Phase field
+            const setField = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) {
+                  projectV2Item {
+                    id
+                  }
+                }
+              }
+            `;
+
+            await github.graphql(setField, {
+              projectId,
+              itemId,
+              fieldId,
+              optionId
+            });
+
+            console.log(`Phase set to "${phaseName}" for issue #${context.payload.issue.number}`);

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ docker.env
 .env
 
 # Ignore Cursor files
-.cursor/rules/push.mdc
 .cursor/environment.json
 
 # PHPUnit cache

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Pagekit 1.1.3 - E2E Hardening & Auth Bugfix (February 14, 2026)
+## Pagekit 1.1.3 - E2E Hardening & Auth Bugfix (February 15, 2026)
+
+### ✨ New Features
+
+- **GitHub Issue Creator Skill** - Added `.cursor/skills/github-issue-creator/` skill for creating GitHub issues with correct labels, milestones, and PR linking.
 
 ### 🐛 Bug Fixes
 
@@ -15,13 +19,16 @@
 
 ### 📝 Documentation
 
-- **ROADMAP** - Expanded Rule 3 (Breaking Changes Allowed Internally) with scope clarification for internal API, platform API and public API. Added Vue 3 migration substeps 3.4.1–3.4.5 (axios, mitt, @vue/compat, Pinia, deps).
+- **ROADMAP** - Expanded Rule 3 (Breaking Changes Allowed Internally) with scope clarification for internal API, platform API and public API. Added Vue 3 migration substeps 3.4.1–3.4.5 (axios, mitt, @vue/compat, Pinia, deps). Aligned task table column widths and sub-task arrows (↳) for consistency.
+- **GitHub Labels Rule** - Synced with GitHub (28 labels, 2026-02-14); added phase labels section and CLI management section; streamlined examples.
 - **E2E Test Plan** - Updated to v2.2 with 96 tests across 12 specs; added folder structure, phase annotations and scope disclaimers.
 - **E2E README** - Documented workers config, rate-limiting verification steps, installation test prerequisites and browser-specific run commands.
-- **GitHub Guide** - New `GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md` for workflow improvement with Projects, Issues and Actions.
+- **GitHub Guide** - New `GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md` for workflow improvement with Projects, Issues and Actions. Phase field values aligned to `phase-1` … `phase-5`; removed redundant label list from guide.
 
 ### 🔧 Maintenance
 
+- **GitHub Actions** - Added `.github/workflows/project-auto-phase.yml` for project automation.
+- **.gitignore** - Removed `.cursor/rules/push.mdc` from ignore list so the push workflow rule is tracked.
 - **package.json** - Fixed `test:e2e:install` script path to `specs/01-setup/installation.spec.js`.
 - **playwright.config.js** - Workers now read from `testConfig.getWorkers()` instead of hardcoded value.
 - **test-config.example.json** - Updated default port to 8180 (Docker E2E); added `workers` setting; removed BOM.

--- a/migration-docs/GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md
+++ b/migration-docs/GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md
@@ -93,7 +93,7 @@ Du hast bereits: Project erstellt, 117 PRs importiert, Board-View mit Standard-S
 
 1. Im Project oben rechts: **„+"** (oder Feld-Menu in Table-View) → **New field**.
 2. Name: `Phase`, Typ: **Single Select**.
-3. Werte anlegen: `1`, `2`, `3`, `4`, `5`.
+3. Werte anlegen: `phase-1`, `phase-2`, `phase-3`, `phase-4`, `phase-5`.
 4. Speichern.
 
 ### Schritt 2: Allen 117 PRs die Phase zuweisen
@@ -119,9 +119,6 @@ Im Repo `Shadesman5/pagekit` → **Issues → Labels → New label**:
 | `phase-3`  | lila              | Frontend             |
 | `phase-4`  | orange            | Production           |
 | `phase-5`  | grau              | Ideen/Wünsche        |
-| `backend`  | dunkelblau        | Backend-Aufgaben     |
-| `frontend` | türkis            | Frontend-Aufgaben    |
-| `docs`     | gelb              | Dokumentation        |
 
 ### Schritt 5: Milestones in pagekit anlegen
 

--- a/migration-docs/GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md
+++ b/migration-docs/GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md
@@ -93,7 +93,7 @@ Du hast bereits: Project erstellt, 117 PRs importiert, Board-View mit Standard-S
 
 1. Im Project oben rechts: **„+"** (oder Feld-Menu in Table-View) → **New field**.
 2. Name: `Phase`, Typ: **Single Select**.
-3. Werte anlegen: `phase-1`, `phase-2`, `phase-3`, `phase-4`, `phase-5`.
+3. Werte anlegen: `Phase 1`, `Phase 2`, `Phase 3`, `Phase 4`, `Phase 5`.
 4. Speichern.
 
 ### Schritt 2: Allen 117 PRs die Phase zuweisen


### PR DESCRIPTION
Follow-up to merged 1.1.3 work. Adds:

- GitHub Issue Creator skill (`.cursor/skills/github-issue-creator/`)
- project-auto-phase workflow (`.github/workflows/project-auto-phase.yml`)
- ROADMAP: task table alignment, sub-task arrows
- github-labels.mdc: synced with GitHub (28 labels), phase labels, CLI section
- .gitignore: stop ignoring push.mdc
- GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md: phase field values phase-1…phase-5
- CHANGELOG-NEW.md: 1.1.3 block updated with above entries, date Feb 15, 2026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and repository workflow automation; the only behavioral change is a new GitHub Action that updates project metadata on issue label events.
> 
> **Overview**
> Adds GitHub project/issue management tooling: a new Cursor skill `github-issue-creator` with a standardized issue template, label/milestone rules, and parent/sub-issue linking guidance.
> 
> Introduces a GitHub Action (`project-auto-phase.yml`) that reacts to `phase-*` issue labels and sets the GitHub Project “Phase” single-select field via GraphQL (with retries for auto-add race conditions).
> 
> Updates supporting docs/config: `github-labels.mdc` is re-synced/streamlined (adds phase labels + CLI label management), `.cursor/ROADMAP.md` table formatting is normalized with sub-step arrows, the GitHub Projects guide aligns Phase values to `Phase 1..5`, `.gitignore` now tracks `.cursor/rules/push.mdc`, and `CHANGELOG-NEW.md` is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50d8f845d9f461cb1f35398ae231cda1ae7986ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->