### PR TITLE
chore(docs): Improve push workflow and GitHub issue-creator skill

### DIFF
--- a/.cursor/rules/push.mdc
+++ b/.cursor/rules/push.mdc
@@ -1,5 +1,5 @@
 ---
-description: Push workflow with version bump. 1) Check git status, create smart commits (conventional-commits.mdc). 2) Use version-bump skill → update composer.json + app/system/config.php. 3) Update CHANGELOG-NEW.md; commit "chore(release): bump version to X.Y.Z". 4) If README-affected → readme-sync.mdc. 5) Push: develop (protected) → new branch + PR; other branch → push direct. 6) Do not merge.
+description: Push workflow with version bump. 1) Check git status, create smart commits (conventional-commits.mdc). 2) Use version-bump skill → update composer.json + app/system/config.php. 3) Update CHANGELOG-NEW.md; commit "chore(release): bump version to X.Y.Z". 4) If README-affected → readme-sync.mdc. 5) Push: develop (protected) → new branch + PR; other branch → push direct. 6) Issue Linking: include "Closes #X" in PR body for related GitHub Issues. 7) Do not merge.
 alwaysApply: false
 ---
 
@@ -12,4 +12,5 @@ alwaysApply: false
 5. **Push**:
    - On `develop` (protected) → create new branch (CC-style name), push, create/update PR
    - On any other branch → push directly
-6. **Do NOT merge** – user merges after CI/tests pass
+6. **Issue Linking** – when creating a PR, check for related GitHub Issues (e.g. `gh issue list --search "Step X.Y"`). If found, include `Closes #X` in the PR body to create the GitHub Development sidebar link.
+7. **Do NOT merge** – user merges after CI/tests pass

--- a/.cursor/skills/github-issue-creator/SKILL.md
+++ b/.cursor/skills/github-issue-creator/SKILL.md
@@ -103,7 +103,6 @@ echo '{"title":"Phase X: Name","state":"open","description":"..."}' | gh api rep
 
 - **ROADMAP Step**: [X.Y]
 - **Phase**: [Phase number and name]
-- **Discovered by**: [User / Architect / Tester / Verifier / Refactorer]
 - **Depends on**: [Previous step or "None"]
 - **Branch**: `[branch-name]` (if known, otherwise omit)
 
@@ -130,32 +129,39 @@ echo '{"title":"Phase X: Name","state":"open","description":"..."}' | gh api rep
 
 ## PR Linking
 
-### Existing PR (already merged)
+> **Important:** GitHub's "Development" sidebar link on an issue is created by the **PR**, not the issue.
+> A `Related: #17` in the issue body is only documentation — it does NOT create the Development sidebar link.
+> The real linking happens when a PR body contains `Closes #X` or `Fixes #X`.
 
-If a PR already exists for the step, add it to the body:
+### In the Issue Body (documentation only)
+
+Reference related PRs in the issue body for context. This is **not** the GitHub Development link:
 ```markdown
 ## Related
 
 - PR: #17
 ```
 
-### Future PR (will be created)
+### In the PR Body (creates Development link)
 
-When creating a PR later, include in the PR body:
+When creating a PR, include the issue reference in the **PR body** to create the real GitHub Development sidebar link:
 ```markdown
 Closes #42
 ```
-This auto-closes the issue when the PR merges.
+This auto-closes the issue when the PR merges and links it in the Development sidebar.
+
+The `push.mdc` workflow (Step 6) handles this automatically when creating PRs.
 
 ### Multiple PRs
 
-Some steps may have multiple PRs:
+Some steps may have multiple PRs. Reference them in the issue body for documentation:
 ```markdown
 ## Related
 
 - PR: #60 (Symfony HttpFoundation upgrade)
 - PR: #61 (Symfony HttpKernel upgrade)
 ```
+Each PR should contain `Closes #X` or `Related: #X` in its own body for the Development link.
 
 ## Parent Issues and Sub-Issues
 
@@ -171,14 +177,28 @@ Use parent/sub-issue structure when a ROADMAP step has sub-steps:
 
 1. Create the **parent issue** first (e.g. "Step 3.4: Vue 3 Migration")
 2. Create each **sub-issue** (e.g. "Step 3.4.1: HTTP Client Migration")
-3. Link sub-issues to parent using the GitHub CLI:
+3. Link sub-issues to parent using the **GraphQL API** (the `gh issue edit --add-sub-issue` flag does not exist in gh CLI):
 
 ```bash
-# Add sub-issue to parent
-gh issue edit PARENT_NUMBER --repo Shadesman5/pagekit --add-sub-issue SUB_ISSUE_URL
+# 1. Get node IDs of parent and sub-issue
+PARENT_ID=$(gh issue view PARENT_NUMBER --repo Shadesman5/pagekit --json id -q .id)
+SUB_ID=$(gh issue view SUB_NUMBER --repo Shadesman5/pagekit --json id -q .id)
+
+# 2. Write GraphQL mutation to temp file (avoids PowerShell escaping issues)
+echo '{"query":"mutation { addSubIssue(input: { issueId: \"PARENT_ID_HERE\", subIssueId: \"SUB_ID_HERE\" }) { issue { id } subIssue { id } } }"}' > temp-graphql.json
+# Replace PARENT_ID_HERE and SUB_ID_HERE with actual values
+
+# 3. Execute mutation
+gh api graphql --input temp-graphql.json
+
+# 4. Clean up
+rm temp-graphql.json
 ```
 
-Or mention in the parent body:
+> **Note:** On PowerShell, inline JSON escaping with `gh api graphql -f query="..."` is unreliable.
+> Always use `--input` with a temp file for GraphQL mutations.
+
+Also mention sub-issues in the parent body for visibility:
 ```markdown
 ## Sub-Issues
 


### PR DESCRIPTION
## Summary

Cursor cloud agent local changes: documentation improvements for the push workflow and GitHub issue-creator skill.

## Changes

### .cursor/rules/push.mdc
- Add Step 6: **Issue Linking** - when creating a PR, check for related GitHub Issues and include Closes #X in the PR body to create the GitHub Development sidebar link
- Renumber previous step 6 to 7 (Do NOT merge)

### .cursor/skills/github-issue-creator/SKILL.md
- Clarify that the Development sidebar link is created by the PR body (Closes #X), not by issue references
- Split PR Linking section into In the Issue Body (documentation only) vs In the PR Body (creates Development link)
- Add reference to push.mdc workflow for PR creation
- Fix Parent Issues section: gh issue edit --add-sub-issue does not exist - replace with GraphQL API mutation and temp file approach (PowerShell-safe)
- Remove Discovered by from issue template

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to internal Cursor workflows; no runtime code paths affected.
> 
> **Overview**
> Updates the Cursor `push.mdc` workflow to add an explicit **Issue Linking** step requiring `Closes #X` in PR bodies (and renumbers the remaining steps).
> 
> Refines the `github-issue-creator` skill docs by removing the “Discovered by” field from the issue template, clearly separating *issue-body PR references* from *PR-body closing keywords* that create GitHub’s Development sidebar link, and replacing the non-existent `gh issue edit --add-sub-issue` guidance with a GraphQL-based (PowerShell-safe) approach for parent/sub-issue linking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c3694389d50bd78fbbbff6bd0fe4dc63066401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->