### PR TITLE
fix(workflows): use item instead of projectV2Item in addProjectV2ItemById

### DIFF
--- a/.github/workflows/auto-add-to-project-phase.yml
+++ b/.github/workflows/auto-add-to-project-phase.yml
@@ -96,7 +96,7 @@ jobs:
                     projectId: $projectId
                     contentId: $contentId
                   }) {
-                    projectV2Item {
+                    item {
                       id
                     }
                   }
@@ -107,7 +107,7 @@ jobs:
                   projectId,
                   contentId: issueNodeId
                 });
-                itemId = addResult.addProjectV2ItemById.projectV2Item.id;
+                itemId = addResult.addProjectV2ItemById.item.id;
                 console.log(`Added issue #${context.payload.issue.number} to project.`);
               } catch (addErr) {
                 // Race: another automation may have added the issue after our find; addProjectV2ItemById then fails (e.g. duplicate).

--- a/.github/workflows/auto-add-to-project-phase.yml
+++ b/.github/workflows/auto-add-to-project-phase.yml
@@ -134,9 +134,7 @@ jobs:
                   fieldId: $fieldId
                   value: { singleSelectOptionId: $optionId }
                 }) {
-                  projectV2Item {
-                    id
-                  }
+                  clientMutationId
                 }
               }
             `;


### PR DESCRIPTION
## Summary
GitHub GraphQL API changed: `AddProjectV2ItemByIdPayload` now returns `item` instead of deprecated `projectV2Item`.

## Error Fixed
```
Field 'projectV2Item' doesn't exist on type 'AddProjectV2ItemByIdPayload'
```

## Changes
- Update `addProjectV2ItemById` mutation in `auto-add-to-project-phase.yml` to use `item` instead of `projectV2Item`
- Aligns with [GitHub GraphQL API docs](https://docs.github.com/en/graphql/reference/mutations#addprojectv2itembyid)

<!-- metadata
labels: phase-2, bug, migration
milestone: Phase 2: Developer Experience
-->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small workflow-only change that updates GraphQL field selections to match API changes; low blast radius aside from potentially breaking the automation if the schema differs.
> 
> **Overview**
> Updates the `auto-add-to-project-phase.yml` GitHub Actions workflow to use `addProjectV2ItemById { item { id } }` (and read `...item.id`) instead of the removed `projectV2Item` field, restoring the “add issue to project” step.
> 
> Simplifies the `updateProjectV2ItemFieldValue` mutation response selection to `clientMutationId` to avoid depending on a returned item object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87413674ad2ce1d39b0f75b91cb2c150aa508205. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->