### PR TITLE
docs: align documentation with current workflow

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -89,4 +89,4 @@ Einfach "push" im Chat eingeben!
 -   `.cursor/Dockerfile` - Container-Definition
 -   `.cursor/environment.json` - Agent-Konfiguration
 -   `.cursor/*.sh` - Helper Scripts
--   `MODERNISING_PAGEKIT_TODO_LIST.md` - Hauptaufgaben
+-   `MODERNISATION_STRATEGY.md` - Vision & Strategie der Modernisierung

--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,5 +1,8 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
+> **Current Version**: 1.2.4
+> **Current Step**: 2.1 (Static Analysis & Code Quality)
+
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**
 
 1. **NO COMPATIBILITY LAYERS**

--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,7 +1,7 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
 > **Current Version**: 1.2.5
-> **Current Step**: 2.1 (Static Analysis & Code Quality)
+> **Current Step**: 2.1.1 (Tooling-Setup & Baseline)
 
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**
 
@@ -41,70 +41,70 @@
 - ⏳ : Future work.
 - ⏸️ : Paused (Dependency in future step).
 
-| ID     | Task Name                             | Status | Audit | Issue | PR      | Responsibility   |
-| :----- | :------------------------------------ | :----- | :---- | :---- | :------ | :--------------- |
-| 1.1    | Mailer Migration                      | ✅     | 🛡️    | #119  | #17     | Audit Passed     |
-| 1.2    | PHPUnit Update                        | ✅     | 🛡️    | #121  | #31     | Audit Passed     |
-| 1.3    | Security Patches                      | ✅     | 🛡️    | #122  | #30     | Audit Passed     |
-| 1.3.5  | ↳ Dependabot Updates                  | ✅     | 🛡️    | #123  | #32     | Audit Passed     |
-| 1.4    | Safe Minor Updates                    | ✅     | 🛡️    | #124  | #53     | Audit Passed     |
-| 1.5    | Doctrine DBAL 3.x                     | ✅     | 🛡️    | #125  | #54     | Audit Passed     |
-| 1.6    | PSR-11 Container Compatibility        | ✅     | 🛡️    | #126  | #55     | Audit Passed     |
-| 1.7    | Event System Compatibility            | ✅     | 🛡️    | #127  | #56     | Audit Passed     |
-| 1.8    | Routing System Compatibility          | ✅     | 🛡️    | #128  | #57     | Audit Passed     |
-| 1.9    | Symfony 6.4 LTS components            | ✅     | 🛡️    | #129  | #60-#61 | Audit Passed     |
-| 1.10   | PSR-6 Cache                           | ✅     | 🛡️    | #130  | #62     | Audit Passed     |
-| 1.10.5 | ↳ E2E Testing with Playwright         | ✅     | 🛡️    | #135  | #67     | Audit Passed     |
-| 1.11   | ORM Modernization                     | ✅     | 🛡️    | #131  | #97     | Audit Passed     |
-| 1.12   | DB Migration System                   | ✅     | 🛡️    | #132  | #107    | Audit Passed     |
-| 1.13   | Validation Update                     | ✅     | 🛡️    | #133  | #108    | Audit Passed     |
-| 1.13.5 | ↳ Template Security Hardening (CSP)   | ⏸️ 80% | 🛡️    | #136  | #110    | Audit Passed     |
-| 1.14   | Doctrine Attributes                   | ✅     | 🛡️    | #134  | #111    | Audit Passed     |
-| 2.0    | Controller Attributes                 | ✅     | 🛡️    | #142  | #111    | Audit Passed     |
-| 2.0.1  | ↳ PSR-11 Container Vollmodernisierung | ✅     | 🛡️    | #145  | #174    | Audit Passed     |
-| 2.0.1a | ↳ Container Core + Modules (S1+S2)    | ✅     | 🛡️    | #162  | #161    | Audit Passed     |
-| 2.0.1b | ↳ DI Infrastructure                   | ✅     | 🛡️    | #163  | #167    | Audit Passed     |
-| 2.0.1c | ↳ System/Installer/Console + DI       | ✅     | 🛡️    | #164  | #169    | Audit Passed     |
-| 2.0.1d | ↳ Packages + ArrayAccess Removal      | ✅     | 🛡️    | #165  | #171    | Audit Passed     |
-| 2.0.1e | ↳ StaticTrait Removal + DI Final      | ✅     | 🛡️    | #166  | #172    | Audit Passed     |
-| 2.0.2  | ↳ Validator-Translator Integration    | ✅     | 🛡️    | #146  | #175    | Audit Passed     |
-| 2.1    | Static Analysis & Code Quality        | ⏳     | ⏳    | #147  | -       | **Current Step** |
-| 2.1.1  | ↳ Tooling-Setup & Baseline            | ⏳     | ⏳    | #148  | -       | Phase 2          |
-| 2.1.2  | ↳ CI/CD Integration & Quality Gates   | ⏳     | ⏳    | #149  | -       | Phase 2          |
-| 2.1.3  | ↳ `strict_types` Migration            | ⏳     | ⏳    | #150  | -       | Phase 2          |
-| 2.1.4  | ↳ PHPStan Level 5→6 (Return Types)    | ⏳     | ⏳    | #151  | -       | Phase 2          |
-| 2.1.5  | ↳ PHPStan Level 6→7 (Null Safety)     | ⏳     | ⏳    | #152  | -       | Phase 2          |
-| 2.1.6  | ↳ PHPStan Level 7→8 (Strict Typing)   | ⏳     | ⏳    | #153  | -       | Phase 2          |
-| 2.1.7  | ↳ QueryBuilder API Standardization    | ⏳     | ⏳    | #154  | -       | Phase 2          |
-| 2.1.8  | ↳ Infection Mutation Testing          | ⏳     | ⏳    | #155  | -       | Phase 2          |
-| 2.1.9  | ↳ Test Coverage Expansion             | ⏳     | ⏳    | #156  | -       | Phase 2          |
-| 2.2    | CI/CD Pipeline                        | ⏳     | ⏳    | #157  | -       | Phase 2          |
-| 2.3    | Docker Production                     | ⏳     | ⏳    | #158  | -       | Phase 2          |
-| 2.4    | Build Tools                           | ⏳     | ⏳    | #159  | -       | Phase 2          |
-| 2.5    | Extension Safety System               | ⏳     | ⏳    | #160  | -       | Phase 2          |
-| 3.1    | UIkit Update                          | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.2    | Vue 2.7 Bridge                        | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.2.1  | ↳ Template Pre-compilation (CSP)      | ⏳ 20% | ⏳    | -     | -       | Phase 3          |
-| 3.3    | TypeScript                            | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4    | Vue 3 Migration                       | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.1  | ↳ vue-resource → axios                | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.2  | ↳ vue-event-manager → mitt            | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.3  | ↳ Vue 3 Core + @vue/compat            | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.4  | ↳ Pinia State Management              | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.5  | ↳ Deps (intl→Intl, lodash→native)     | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.4.6  | ↳ Translation System Modernization    | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.5    | Component Library                     | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 3.6    | E2E selector strategy (data-testid)   | ⏳     | ⏳    | -     | -       | Phase 3          |
-| 4.1    | Basic Security                        | ⏳     | ⏳    | -     | -       | Phase 4          |
-| 4.2    | REST API v2                           | ⏳     | ⏳    | -     | -       | Phase 4          |
-| 4.3    | Performance Optimization              | ⏳     | ⏳    | -     | -       | Phase 4          |
-| 4.4    | Monitoring & Health Checks            | ⏳     | ⏳    | -     | -       | Phase 4          |
-| 5.1    | Modern Block Editor                   | ⏳     | ⏳    | -     | -       | Phase 5          |
-| 5.2    | Advanced Security                     | ⏳     | ⏳    | -     | -       | Phase 5          |
-| 5.3    | Advanced Performance                  | ⏳     | ⏳    | -     | -       | Phase 5          |
-| 5.4    | Advanced CMS Features                 | ⏳     | ⏳    | -     | -       | Phase 5          |
-| 5.5    | Enterprise Features                   | ⏳     | ⏳    | -     | -       | Phase 5          |
-| 5.6    | Marketplace & Extensions              | ⏳     | ⏳    | -     | -       | Phase 5          |
+| ID     | Task Name                             | Status | Audit | Issue | PR      |
+| :----- | :------------------------------------ | :----- | :---- | :---- | :------ |
+| 1.1    | Mailer Migration                      | ✅     | 🛡️    | #119  | #17     |
+| 1.2    | PHPUnit Update                        | ✅     | 🛡️    | #121  | #31     |
+| 1.3    | Security Patches                      | ✅     | 🛡️    | #122  | #30     |
+| 1.3.5  | ↳ Dependabot Updates                  | ✅     | 🛡️    | #123  | #32     |
+| 1.4    | Safe Minor Updates                    | ✅     | 🛡️    | #124  | #53     |
+| 1.5    | Doctrine DBAL 3.x                     | ✅     | 🛡️    | #125  | #54     |
+| 1.6    | PSR-11 Container Compatibility        | ✅     | 🛡️    | #126  | #55     |
+| 1.7    | Event System Compatibility            | ✅     | 🛡️    | #127  | #56     |
+| 1.8    | Routing System Compatibility          | ✅     | 🛡️    | #128  | #57     |
+| 1.9    | Symfony 6.4 LTS components            | ✅     | 🛡️    | #129  | #60-#61 |
+| 1.10   | PSR-6 Cache                           | ✅     | 🛡️    | #130  | #62     |
+| 1.10.5 | ↳ E2E Testing with Playwright         | ✅     | 🛡️    | #135  | #67     |
+| 1.11   | ORM Modernization                     | ✅     | 🛡️    | #131  | #97     |
+| 1.12   | DB Migration System                   | ✅     | 🛡️    | #132  | #107    |
+| 1.13   | Validation Update                     | ✅     | 🛡️    | #133  | #108    |
+| 1.13.5 | ↳ Template Security Hardening (CSP)   | ⏸️ 80% | 🛡️    | #136  | #110    |
+| 1.14   | Doctrine Attributes                   | ✅     | 🛡️    | #134  | #111    |
+| 2.0    | Controller Attributes                 | ✅     | 🛡️    | #142  | #111    |
+| 2.0.1  | ↳ PSR-11 Container Vollmodernisierung | ✅     | 🛡️    | #145  | #174    |
+| 2.0.1a | ↳ Container Core + Modules (S1+S2)    | ✅     | 🛡️    | #162  | #161    |
+| 2.0.1b | ↳ DI Infrastructure                   | ✅     | 🛡️    | #163  | #167    |
+| 2.0.1c | ↳ System/Installer/Console + DI       | ✅     | 🛡️    | #164  | #169    |
+| 2.0.1d | ↳ Packages + ArrayAccess Removal      | ✅     | 🛡️    | #165  | #171    |
+| 2.0.1e | ↳ StaticTrait Removal + DI Final      | ✅     | 🛡️    | #166  | #172    |
+| 2.0.2  | ↳ Validator-Translator Integration    | ✅     | 🛡️    | #146  | #175    |
+| 2.1    | **Static Analysis & Code Quality**    | ⏳     | ⏳    | #147  | -       |
+| 2.1.1  | ↳ Tooling-Setup & Baseline            | ⏳     | ⏳    | #148  | -       |
+| 2.1.2  | ↳ CI/CD Integration & Quality Gates   | ⏳     | ⏳    | #149  | -       |
+| 2.1.3  | ↳ `strict_types` Migration            | ⏳     | ⏳    | #150  | -       |
+| 2.1.4  | ↳ PHPStan Level 5→6 (Return Types)    | ⏳     | ⏳    | #151  | -       |
+| 2.1.5  | ↳ PHPStan Level 6→7 (Null Safety)     | ⏳     | ⏳    | #152  | -       |
+| 2.1.6  | ↳ PHPStan Level 7→8 (Strict Typing)   | ⏳     | ⏳    | #153  | -       |
+| 2.1.7  | ↳ QueryBuilder API Standardization    | ⏳     | ⏳    | #154  | -       |
+| 2.1.8  | ↳ Infection Mutation Testing          | ⏳     | ⏳    | #155  | -       |
+| 2.1.9  | ↳ Test Coverage Expansion             | ⏳     | ⏳    | #156  | -       |
+| 2.2    | CI/CD Pipeline                        | ⏳     | ⏳    | #157  | -       |
+| 2.3    | Docker Production                     | ⏳     | ⏳    | #158  | -       |
+| 2.4    | Build Tools                           | ⏳     | ⏳    | #159  | -       |
+| 2.5    | Extension Safety System               | ⏳     | ⏳    | #160  | -       |
+| 3.1    | UIkit Update                          | ⏳     | ⏳    | -     | -       |
+| 3.2    | Vue 2.7 Bridge                        | ⏳     | ⏳    | -     | -       |
+| 3.2.1  | ↳ Template Pre-compilation (CSP)      | ⏳ 20% | ⏳    | -     | -       |
+| 3.3    | TypeScript                            | ⏳     | ⏳    | -     | -       |
+| 3.4    | Vue 3 Migration                       | ⏳     | ⏳    | -     | -       |
+| 3.4.1  | ↳ vue-resource → axios                | ⏳     | ⏳    | -     | -       |
+| 3.4.2  | ↳ vue-event-manager → mitt            | ⏳     | ⏳    | -     | -       |
+| 3.4.3  | ↳ Vue 3 Core + @vue/compat            | ⏳     | ⏳    | -     | -       |
+| 3.4.4  | ↳ Pinia State Management              | ⏳     | ⏳    | -     | -       |
+| 3.4.5  | ↳ Deps (intl→Intl, lodash→native)     | ⏳     | ⏳    | -     | -       |
+| 3.4.6  | ↳ Translation System Modernization    | ⏳     | ⏳    | -     | -       |
+| 3.5    | Component Library                     | ⏳     | ⏳    | -     | -       |
+| 3.6    | E2E selector strategy (data-testid)   | ⏳     | ⏳    | -     | -       |
+| 4.1    | Basic Security                        | ⏳     | ⏳    | -     | -       |
+| 4.2    | REST API v2                           | ⏳     | ⏳    | -     | -       |
+| 4.3    | Performance Optimization              | ⏳     | ⏳    | -     | -       |
+| 4.4    | Monitoring & Health Checks            | ⏳     | ⏳    | -     | -       |
+| 5.1    | Modern Block Editor                   | ⏳     | ⏳    | -     | -       |
+| 5.2    | Advanced Security                     | ⏳     | ⏳    | -     | -       |
+| 5.3    | Advanced Performance                  | ⏳     | ⏳    | -     | -       |
+| 5.4    | Advanced CMS Features                 | ⏳     | ⏳    | -     | -       |
+| 5.5    | Enterprise Features                   | ⏳     | ⏳    | -     | -       |
+| 5.6    | Marketplace & Extensions              | ⏳     | ⏳    | -     | -       |
 
 ## **🛠️ TECHNICAL STACK REFERENCE**
 

--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,6 +1,6 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
-> **Current Version**: 1.2.4
+> **Current Version**: 1.2.5
 > **Current Step**: 2.1 (Static Analysis & Code Quality)
 
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**

--- a/.cursor/rules/feature-branch.mdc
+++ b/.cursor/rules/feature-branch.mdc
@@ -1,4 +1,4 @@
 ---
-description: Feature Branch Workflow - Manages feature development with automatic documentation. Steps: 1) When starting a new feature, create branch 'feature/[name]' from 'develop'; 2) Track all changes and categorize them (Breaking/Feature/Enhancement/Fix); 3) On feature completion: a) Generate comprehensive CHANGELOG-NEW.md entry with full details; b) Update README.md if feature affects system requirements or major functionality; c) Write PR documentation to migration-docs/pull-requests/PR_[feature-name].md with detailed description including: What changed, Why it was needed, How to test, Migration notes if applicable.
+description: Feature Branch Workflow - Manages feature development. Steps: 1) When starting a new feature, create branch 'feature/[name]' from 'develop'; 2) Track all changes and categorize them (Breaking/Feature/Enhancement/Fix); 3) On feature completion: a) Generate comprehensive CHANGELOG-NEW.md entry with full details; b) Update README.md if feature affects system requirements or major functionality; c) Follow push.mdc for version bump, push, and PR creation with metadata block.
 alwaysApply: false
 ---

--- a/.cursor/skills/github-issue-creator/SKILL.md
+++ b/.cursor/skills/github-issue-creator/SKILL.md
@@ -330,7 +330,7 @@ rm temp-issue-body.md
 > The agent CANNOT close or delete issues it creates. A runaway batch is irreversible.
 > Use `issue-cleanup.yml` (GitHub UI) to bulk-close accidental issues.
 
-1. Read source file (e.g. `MODERNISING_PAGEKIT_TODO_LIST.md` or `ROADMAP.md`)
+1. Read source file (e.g. `MODERNISATION_STRATEGY.md` or `ROADMAP.md`)
 2. Parse each step: number, title, status, sub-steps, related PR
 3. **Skip** `✅` completed steps unless user says otherwise
 4. **Duplicate check** for every issue (MANDATORY, see "Check Before Creating")

--- a/.cursor/tickets/README.md
+++ b/.cursor/tickets/README.md
@@ -22,13 +22,7 @@ Subagent tasks are delegated via files in this folder. The Orchestrator only ass
 
 ## Optional: output for human
 
-In the task prompt or in the invocation template you can set:
-
-```text
-Output for human (optional): migration-docs/pull-requests/PR_PSR-11-DI.md
-```
-
-Then the task prompt can instruct who writes it (e.g. "At the end, write a short PR summary to Output for human path"). That file is the single artifact you need to read; the rest stays in tickets and code.
+The task prompt or invocation template can specify a summary file path for human review. This is optional — the primary output is the PR itself (created via `push.mdc`).
 
 ## Git
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules
 # Exception: agent_prompts for orchestrated task execution (referenced by .cursor/rules)
 !/migration-docs/TODO/agent_prompts/
 !/migration-docs/TODO/agent_prompts/**
+!/migration-docs/TODO/MODERNISATION_STRATEGY.md
 
 # Ignore environment files with secrets
 docker.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,4 @@ Pagekit CMS is a modular PHP CMS built on Symfony 6.4 components with a Vue.js 2
 - **Writable directories needed:** `tmp/` (logs, cache, temp, packages) and `storage/` must be writable. Create them with `mkdir -p tmp/logs tmp/cache tmp/temp tmp/packages storage`.
 - **`php pagekit start`** is documented in README but just wraps `php -S 0.0.0.0:8080 index.php`. Use the direct command for more control.
 - **E2E tests (Playwright)** require the dev server running and a completed installation. Config at `tests/e2e/config/test-config.json` (copy from `.example.json`).
+- **Modernisation workflow** is defined in `.cursor/rules/` (push.mdc, feature-branch.mdc, orchestrator-subagent-workflow.mdc) and `.cursor/ROADMAP.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Pagekit CMS is a modular PHP CMS built on Symfony 6.4 components with a Vue.js 2
 | Service | Command | Notes |
 |---|---|---|
 | PHP dev server | `php -S localhost:8080 index.php` | Serves the full app; run from workspace root |
-| PHPUnit | `./app/vendor/bin/phpunit` | 261 tests; no external DB needed |
+| PHPUnit | `./app/vendor/bin/phpunit` | 280 tests; no external DB needed |
 | ESLint | `yarn lint` | Pre-existing style errors (~13k); runs correctly |
 | Webpack (JS build) | `yarn compile-js --mode=production` | Or `yarn watch-js` for dev |
 | Gulp (LESS build) | `yarn compile-less` | Or `yarn watch-less` for dev |

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Pagekit 1.2.5 - Documentation Cleanup & Workflow Alignment (March 28, 2026)
+
+### Documentation
+
+- **Stale file references updated** — Replaced all references to removed `MODERNISING_PAGEKIT_TODO_LIST.md` with `MODERNISATION_STRATEGY.md` or `ROADMAP.md` across `.cursor/README.md`, `github-issue-creator/SKILL.md`, and `tests/e2e/COMPLETE_TEST_PLAN.md`.
+- **migration-docs README restructured** — Cleaned up layout: flat file listings, archived `branches/` and `pull-requests/` sections as historical Phase 1 artifacts, added tracking/navigation table pointing to ROADMAP as SSOT, updated timeline to reflect Phase 2 active status.
+- **ROADMAP header added** — Current version (1.2.5) and current step (2.1) now shown at the top of `.cursor/ROADMAP.md` for quick orientation.
+- **AGENTS.md extended** — Added modernisation workflow note referencing `.cursor/rules/` and `ROADMAP.md`.
+- **Feature-branch rule simplified** — Removed outdated PR documentation path; now references `push.mdc` for version bump, push, and PR creation.
+- **Tickets README simplified** — Replaced verbose output-for-human section with concise reference to `push.mdc`.
+
+---
+
 ## Pagekit 1.2.4 - Validator-Translator Integration + Audit (March 27, 2026)
 
 ### Features
@@ -27,6 +40,8 @@
 
 - **Deferred TODO for ExtensionTranslateCommand** — Added `TODO: Step 2.0.2` marker in `PhpNodeVisitor.php` for future `#[Assert\...]` attribute key extraction (low priority, deferred to Step 2.1).
 
+---
+
 ## Pagekit 1.2.3 - PSR-11 Container Closure Audit (March 26, 2026)
 
 ### 🛡️ Audit
@@ -43,6 +58,8 @@
 
 - **ROADMAP updated** — Step 2.0.1 marked as ✅ with audit 🛡️; sub-steps 2.0.1a–e audit columns set to 🛡️; Step 2.0.2 advanced to **Current Step**.
 
+---
+
 ## Pagekit 1.2.2 - Task Prompts & Agent Roles (March 26, 2026)
 
 ### 📁 Documentation
@@ -57,6 +74,8 @@
 - **Refactorer** — Explicit boundary: no test execution, no self-verification.
 - **Verifier** — Restricted to static code review only; no PHPUnit, Playwright, or application commands.
 - **Tester** — Declared as exclusive test runner. Added clean-state rule: `rm -f pagekit.db config.php` before any fresh installation.
+
+---
 
 ## Pagekit 1.2.1 - PSR-11 StaticTrait Removal Bugfixes (March 26, 2026)
 

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.2.4'
+        'version' => '1.2.5'
 
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pagekit/pagekit",
   "title": "Pagekit",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "project",
   "description": "The Pagekit CMS",
   "keywords": [

--- a/migration-docs/README.md
+++ b/migration-docs/README.md
@@ -4,93 +4,63 @@ Diese Sammlung enthält alle wichtigen Dokumentationen zur Modernisierung und Mi
 
 ## 📁 Struktur
 
+### 📋 `/TODO/` — Planung & Phasen (aktiv)
+
+-   **MODERNISATION_STRATEGY.md** — Vision, Philosophie und strategische Entscheidungen
+-   **PHASE#1_MODERNISING.md** .. **PHASE#5_FUTURE_VISION.md** — Detaillierte Schritte pro Phase
+-   **agent_prompts/** — Agent-Prompts für konkrete Migrationsschritte
+-   **GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md** — GitHub Projects, Issues und Actions Leitfaden
+
 ### 🔒 `/security/`
 
-Sicherheitsupdates und Patches
-
--   **completed/**
-    -   **SECURITY_PATCHES.md** - Finales Security Patch Dokument (September 19, 2025)
--   **process/**
-    -   **SECURITY_PATCHES_IMPLEMENTATION.md** - Detailliertes Implementierungslog
+-   **completed/SECURITY_PATCHES.md** — Finales Security Patch Dokument
+-   **process/SECURITY_PATCHES_IMPLEMENTATION.md** — Detailliertes Implementierungslog
 
 ### 📦 `/dependencies/`
 
-Abhängigkeiten-Management und Updates
-
--   **completed/**
-    -   **DEPENDABOT_UPDATES.md** - Automatisierte Dependabot-Updates
--   **process/**
-    -   **dependency-analysis.md** - Analyse aller Projekt-Abhängigkeiten
-    -   **SYMFONY_64_CHANGES.md** - Strategie für Symfony 6.4 Migration
+-   **completed/DEPENDABOT_UPDATES.md** — Automatisierte Dependabot-Updates
+-   **process/dependency-analysis.md** — Analyse aller Projekt-Abhängigkeiten
+-   **process/SYMFONY_64_CHANGES.md** — Strategie für Symfony 6.4 Migration
 
 ### 🧪 `/testing/`
 
-Test-Dokumentation und Ergebnisse
-
--   **completed/**
-    -   **TEST_IMPROVEMENTS.md** - Verbesserungen am Testsystem
-    -   **test-results.txt** - Aktuelle Testergebnisse
+-   **completed/TEST_IMPROVEMENTS.md** — Verbesserungen am Testsystem
 
 ### 📧 `/mail/`
 
-Mail-System Migration
-
--   **completed/**
-    -   **MAIL_MIGRATION.md** - Mail-System Migration
-    -   **MAIL_MIGRATION_ANALYSIS.md** - Performance-Analyse der Migration
-
-### 🔄 `/pull-requests/`
-
-PR-Dokumentation und Git-Workflows
-
--   **PR_DESCRIPTION.md** - PR-Beschreibungsvorlagen
--   **PR_PHPUNIT_11_UPGRADE.md** - PHPUnit 11 Upgrade PR
+-   **completed/MAIL_MIGRATION.md** — Mail-System Migration
 
 ### 📚 `/documentation/`
 
-Meta-Dokumentation und Workflows
+-   **CURSOR_RULES_OVERVIEW.md** — Übersicht der Cursor-Regeln
+-   **DOCUMENTATION_AUTOMATION.md** — Automatisierung der Dokumentation
 
--   **CURSOR_RULES_OVERVIEW.md** - Übersicht der Cursor-Regeln
--   **DOCUMENTATION_AUTOMATION.md** - Automatisierung der Dokumentation
--   **MODERNISING_PAGEKIT_TODO_LIST.md** - Haupt-TODO-Liste für die Modernisierung
+### 📦 `/branches/` — Historisches Archiv (Phase 1)
 
-### 📋 `/TODO/`
+> Diese Dateien dokumentieren abgeschlossene Phase-1 Branches.
+> Sie werden nicht mehr aktiv gepflegt — der aktuelle Workflow nutzt GitHub PRs direkt.
 
-Planung, Phasen und Workflow-Guides
+### 📦 `/pull-requests/` — Historisches Archiv (Phase 1)
 
--   **GITHUB_PROJECTS_ISSUES_ACTIONS_GUIDE.md** - Detaillierter Leitfaden: GitHub Projects, Issues und Actions für die Modernisierung (Workflow-Verbesserung, weniger Repo-Dateien)
--   **MODERNISING_PAGEKIT_TODO_LIST.md** - Siehe auch `/documentation/`
--   **PHASE#1_MODERNISING.md**, **PHASE#2_MODERNISING.md** - Detaillierte Schritte pro Phase
--   **agent_prompts/** - Agent-Prompts für konkrete Migrationsschritte
+> PR-Zusammenfassungen aus dem alten Workflow (vor Cloud-Agenten).
+> Aktuelle PRs werden direkt auf GitHub erstellt — siehe `push.mdc`.
 
-## 🔍 Wichtige Hinweise
+## 🔍 Tracking & Navigation
 
-### Aktuelle Prioritäten
-
-1. **Security Patches** - Alle kritischen Sicherheitslücken sind behoben
-2. **Dependency Updates** - Laufende Aktualisierung veralteter Pakete
-3. **Testing** - Verbesserung der Testabdeckung
-4. **Documentation** - Kontinuierliche Dokumentationspflege
-
-### Ordnerstruktur
-
--   **completed/** - Alle finalen, abgeschlossenen Dokumente
--   **process/** - Arbeits-/Prozessdokumente und Analysen
--   **documentation/** - Meta-Dokumentation und Workflows
+| Was | Wo |
+|---|---|
+| **Fortschritt & Status** | [ROADMAP.md](../.cursor/ROADMAP.md) (einzige SSOT) |
+| **Vision & Strategie** | [MODERNISATION_STRATEGY.md](TODO/MODERNISATION_STRATEGY.md) |
+| **Technische Details** | `TODO/PHASE#X_*.md` (pro Phase) |
+| **Agent Workflow** | `.cursor/rules/` (push.mdc, feature-branch.mdc, orchestrator) |
 
 ## 📅 Timeline
 
 -   **Start**: September 2025
--   **Aktiv**: Fortlaufende Modernisierung
--   **Ziel**: Vollständig modernisiertes Pagekit CMS
-
-## 🛠 Workflow
-
-1. Neue Migrationsdokumente in den passenden Unterordner ablegen
-2. README bei strukturellen Änderungen aktualisieren
-3. Veraltete Dokumente archivieren oder löschen
-4. Regelmäßige Reviews durchführen
+-   **Phase 1**: Abgeschlossen (17/17 Schritte, Version 1.1.0)
+-   **Phase 2**: Aktiv (Static Analysis & Code Quality)
+-   **Ziel**: Pagekit 2.0.0 (Production-Ready)
 
 ---
 
-_Zuletzt aktualisiert: 19. September 2025_
+_Zuletzt aktualisiert: März 2026_

--- a/migration-docs/TODO/MODERNISATION_STRATEGY.md
+++ b/migration-docs/TODO/MODERNISATION_STRATEGY.md
@@ -1,0 +1,282 @@
+# Pagekit CMS Modernisation Strategy
+
+> This document defines the **vision, philosophy, and strategic decisions** behind the Pagekit modernisation.
+> It is intentionally static — progress tracking lives exclusively in [ROADMAP.md](../../.cursor/ROADMAP.md).
+
+## Übersicht
+
+Dieser strategische Plan führt Pagekit CMS von der aktuellen Legacy-Basis zu einem modernen, sicheren und wartbaren System. Jeder Schritt wird in einem eigenen Git-Branch durchgeführt und über Pull Requests geprüft.
+
+**Wichtiges Prinzip: Erst komplett modernisieren, dann neue Features bauen!**
+
+## Phase Definitions
+
+| Phase | Name | Goal | Detail File |
+|---|---|---|---|
+| 0 | Preparation | Stable, traceable baseline | *(completed)* |
+| 1 | Core Backend Modernisation | Renew the foundation (PHP 8.2+, Symfony 6.4, Doctrine DBAL 3) | `PHASE#1_MODERNISING.md` |
+| 2 | Developer Experience | Quality tools, CI/CD, Docker, static analysis | `PHASE#2_MODERNISING.md` |
+| 3 | Frontend Modernisation | Vue 3, UIkit 3.21+, TypeScript, modern build tools | `PHASE#3_MODERNISING.md` |
+| 4 | Production-Ready Release | Essential features for Pagekit 2.0 (2FA, REST API v2, Performance) | `PHASE#4_MODERNISING.md` |
+| 5 | Advanced & Enterprise | Optional post-2.0 features, extensions, marketplace | `PHASE#5_FUTURE_VISION.md` |
+
+### Visuelle Roadmap
+
+```
+Phase 1: Core Backend-Modernisierung
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ Mailer, PHPUnit, Security   ┃
+    ├─ Doctrine DBAL 3.x           ┃
+    ├─ PSR-11, Events, Routing     ┃
+    ├─ Symfony 6.4 LTS, PSR-6     ┃
+    ├─ ORM, DB Migrations          ┃
+    └─ Validation, Attributes ━━━━┛
+          ⬇️
+Phase 2: Developer Experience
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ Controller + DI Attributes  ┃
+    ├─ PSR-11 Container Modern.    ┃
+    ├─ Static Analysis (PHPStan)   ┃
+    ├─ CI/CD Pipeline              ┃
+    ├─ Docker Production           ┃
+    ├─ Build Tools Modernization   ┃
+    └─ Extension Safety System ━━━┛
+          ⬇️
+Phase 3: Frontend-Modernisierung
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ UIkit 3.5 → 3.21+ Update         ┃
+    ├─ Vue 2.7 Bridge                    ┃
+    ├─ CSP Template Pre-compilation      ┃
+    ├─ TypeScript Integration            ┃
+    ├─ Vue 3 Migration:                  ┃
+    │  ├─ vue-resource → axios           ┃
+    │  ├─ vue-event-manager → mitt       ┃
+    │  ├─ Vue 3 Core + @vue/compat       ┃
+    │  ├─ Pinia State Management         ┃
+    │  └─ vee-validate v4, lodash → ES6  ┃
+    ├─ Component Library                 ┃
+    └─ E2E Selector Strategy ━━━━━━━━━━━┛
+          ⬇️
+Phase 4: Production-Ready (→ 2.0.0)
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ 2FA + OAuth2 Social Login 🔐┃
+    ├─ REST API v2 (OpenAPI, JWT)  ┃
+    ├─ Performance Optimization    ┃
+    └─ Monitoring & Health ━━━━━━━┛ PRODUCTION READY 🚀
+          ⬇️
+Phase 5: Advanced & Enterprise (Post-2.0)
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ PKBlocks Editor 📝          ┃
+    ├─ OAuth2 Server               ┃
+    ├─ Advanced Performance        ┃
+    ├─ Advanced CMS (PWA, AI)      ┃
+    ├─ Enterprise (Multi-Tenancy)  ┃
+    └─ Marketplace & Store ━━━━━━━┛
+          ⬇️
+Future: Next Generation (3.x+)
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ├─ Headless CMS Mode           ┃
+    ├─ Cloud-Native                ┃
+    ├─ Advanced AI                 ┃
+    └─ Mobile-First ━━━━━━━━━━━━━━┛
+```
+
+---
+
+## 🎯 Pagekit DNA: Leicht & Modular bleiben!
+
+**⚠️ WICHTIG: Wir bauen kein WordPress 2.0!**
+
+Pagekit's Kernphilosophie:
+
+- ✅ **Leichtgewichtig** — Minimaler Core, Features über Extensions
+- ✅ **Modular** — Alles ist ein Modul/Extension
+- ✅ **Einfach** — Klare Struktur, keine Bloatware
+- ✅ **Entwicklerfreundlich** — Modern, aber nicht überladen
+
+### Wie passt unsere Roadmap dazu?
+
+#### Phase 1-3: Foundation ✅ PASST!
+
+- Modernisierung bestehender Core-Features
+- Keine neuen Features, nur bessere Basis
+- Bleibt schlank und fokussiert
+
+#### Phase 4: Production (2.0.0) ✅ PASST!
+
+**Core-Features (eingebaut):**
+
+- ✅ 2FA — Security Essential
+- ✅ **OAuth2 Client** — Social Login (Google, GitHub, etc.)
+- ✅ REST API v2 — Moderne Schnittstelle
+- ✅ Performance — Cache, Optimierung
+- ✅ Monitoring — Production Essentials
+
+**Warum diese im Core?**
+
+- Notwendig für Production
+- Geringe Komplexität (mit Libraries)
+- Moderne Erwartung (Social Login Standard)
+- Stabil und bewährt
+
+#### Phase 5: Advanced (2.1.0+) ⚠️ VORSICHT!
+
+**Als Extensions realisieren (NICHT Core!):**
+
+- ⚠️ **PKBlocks Editor** → **Extension** (Block-Editor, optional!)
+- ⚠️ **OAuth2 Server** → **Extension** (Pagekit als Auth-Provider, Enterprise!)
+- ⚠️ **SAML/SSO** → **Extension** (Enterprise-Kunden)
+- ⚠️ **Multi-Tenancy** → **Extension** (komplexe Setups + Test-Umgebungen)
+- ⚠️ **AI Assistant** → **Extension** (spezielle Use-Cases)
+- ⚠️ **PWA** → **Extension** (nicht jeder braucht es)
+
+### 📦 Extension-First Strategie
+
+**Regel für Phase 5:**
+
+1. **Frage:** Braucht das JEDER?
+   - ✅ Ja → Core
+   - ❌ Nein → Extension
+
+2. **Frage:** Erhöht das die Komplexität erheblich?
+   - ✅ Ja → Extension
+   - ❌ Nein → Core (mit Feature Flag)
+
+3. **Frage:** Ist das ein Nischen-Feature?
+   - ✅ Ja → Extension
+   - ❌ Nein → Evaluieren
+
+**Beispiele:**
+
+- ✅ **2FA Core** — Security braucht jeder
+- ✅ **OAuth2 Client Core** — Social Login ist moderner Standard
+- ❌ **OAuth2 Server Extension** — Auth-Provider ist Enterprise Feature
+- ❌ **Block-Editor Extension** — Nicht jeder braucht Block-Style
+- ✅ **REST API Core** — Moderne API ist Standard
+- ❌ **GraphQL Extension** — Nischen-Feature
+- ✅ **Cache Core** — Performance braucht jeder
+- ❌ **Multi-Tenancy Extension** — Spezielle Anforderung (Test + Enterprise)
+
+### 🔄 Entscheidungsbaum: Core vs. Extension
+
+```
+Neues Feature geplant?
+    │
+    ├─ Braucht es JEDER Nutzer?
+    │  ├─ JA → Weiter
+    │  └─ NEIN → ⚠️ EXTENSION
+    │
+    ├─ Ist es ein Security/Performance Essential?
+    │  ├─ JA → ✅ CORE
+    │  └─ NEIN → Weiter
+    │
+    ├─ Erhöht es Core-Komplexität stark?
+    │  ├─ JA → ⚠️ EXTENSION
+    │  └─ NEIN → Weiter
+    │
+    ├─ Kann es als Service/API bereitgestellt werden?
+    │  ├─ JA → ✅ CORE (als API/Service)
+    │  └─ NEIN → Weiter
+    │
+    └─ Default: ⚠️ EXTENSION (wenn unsicher)
+```
+
+### 🎨 Marketplace als Lösung
+
+**Phase 5.6: Marketplace** wird zum Schlüssel:
+
+- Extensions einfach installieren
+- Offiziell geprüfte Extensions
+- Community Extensions
+- Theme Store
+
+### 📏 Größenvergleich: Bleiben wir leicht?
+
+**Pagekit 2.0.0 (Ziel):**
+
+```
+Core System: ~10 MB (leichte Zunahme durch moderne Features)
+Vendor: ~15 MB (Symfony 6.4, moderne Dependencies)
+Total: ~25 MB ✅ IMMER NOCH LEICHT!
+
+Vergleich:
+- WordPress: ~50-80 MB Core (ohne Plugins!)
+- Drupal: ~100+ MB
+- Joomla: ~40-60 MB
+- Ghost: ~30 MB
+- Pagekit 2.0: ~25 MB ✅ PERFEKT!
+```
+
+**Regel:**
+
+- ✅ Core bleibt unter 30 MB
+- ✅ Extensions optional installierbar
+- ✅ User entscheidet, was sie brauchen
+
+### 🚫 Was wir NICHT werden wollen
+
+- ❌ WordPress-Klon (zu überladen)
+- ❌ Drupal-Komplex (zu kompliziert)
+- ❌ Joomla-Chaos (zu unübersichtlich)
+
+**Was wir sein wollen:**
+
+- ✅ Ghost-ähnlich (Modern, fokussiert)
+- ✅ Statamic-ähnlich (Developer-friendly)
+- ✅ Pagekit 2.0 (Leicht, modular, modern)
+
+---
+
+## 🛠 Foundation First Strategie
+
+**Warum erst alles modernisieren, dann neue Features?**
+
+1. **Keine doppelte Arbeit**: Features auf modernem Stack bauen statt später migrieren
+2. **Bessere Qualität**: Neue Features nutzen direkt moderne Best Practices
+3. **Weniger Bugs**: Testing Infrastructure vorhanden bevor neue Features kommen
+4. **Einfachere Wartung**: Konsistente, moderne Codebase
+
+---
+
+## 📊 Versionierungsstrategie
+
+**WICHTIG: Die MAJOR.MINOR.PATCH Strategie ist ab Phase 4 vorgesehen, davor ist es STATE.MAJOR.MINOR-PATCH**
+
+### PATCH Version (1.0.x → 1.0.y)
+
+- ✅ **Bugfixes** — Behebung von Fehlern
+- ✅ **Security Patches** — Sicherheitsupdates
+- ✅ **Dependency Updates** — Aktualisierung von Abhängigkeiten
+- ✅ **Modernisierungen** — Code-Verbesserungen ohne neue Features
+
+### MINOR Version (1.x.0 → 1.y.0)
+
+- 🆕 **Neue Features** — Neue Funktionalität
+- 🔄 **Phase-Abschluss** — Eine komplette Phase wurde abgeschlossen
+- 🏗️ **Architektur-Änderungen** — Große strukturelle Verbesserungen
+- ⚠️ **Breaking Changes** — Änderungen, die Extensions betreffen könnten
+
+### MAJOR Version (x.0.0 → y.0.0)
+
+- 🚀 **Production Release** — System ist production-ready
+- 💥 **Massive Breaking Changes** — Grundlegende Architektur-Änderungen
+- 🎉 **Komplett neue Version** — Neue Generation des Systems
+
+---
+
+## 🧭 Grundprinzipien
+
+1. **PHP Version**: Minimum PHP 8.2 für moderne Features
+2. **Test First**: Jede Änderung muss durch Tests abgesichert sein
+3. **Incremental**: Kleine, testbare Schritte statt Big-Bang-Updates
+4. **Documentation**: Jede Phase produziert Dokumentation
+5. **No Backward Compatibility**: Radikal entfernen!
+6. **Security First**: Sicherheit hat immer Priorität!
+
+## ⚠️ Risikomanagement
+
+- ⚠️ **Breaking Changes** dokumentieren und kommunizieren
+- ⚠️ **Extension Compatibility** prüfen und migrieren, keine compatibility layer!
+- ⚠️ **Performance Regression** durch Benchmarking vermeiden
+- ⚠️ **Security Vulnerabilities** sofort patchen
+- ⚠️ **Technical Debt** kontinuierlich abbauen

--- a/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/PROMPT_2_1_1_Tooling-Setup-Baseline.md
+++ b/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/PROMPT_2_1_1_Tooling-Setup-Baseline.md
@@ -24,9 +24,10 @@
 ```bash
 ./app/vendor/bin/phpunit
 ```
+**Expected: ~280 tests, all passing.** If significantly fewer tests run, investigate configuration issues.
 **IF ANY FAILS → STOP AND FIX!**
 
-**Before starting:** Branch from `develop`.
+**Before starting:** Verify: Branch is Up-to-Date with `develop`.
 
 ---
 
@@ -45,6 +46,10 @@ composer require --dev phpstan/phpstan phpstan/phpstan-doctrine phpstan/phpstan-
 Create `phpstan.neon` in workspace root:
 
 ```neon
+includes:
+    - app/vendor/phpstan/phpstan-doctrine/extension.neon
+    - app/vendor/phpstan/phpstan-symfony/extension.neon
+
 parameters:
     level: 5
     paths:
@@ -64,9 +69,12 @@ parameters:
 ```
 
 Adjust paths based on discovery. The config must:
+- Include the Doctrine and Symfony extension `.neon` files (without these, the extensions are installed but inactive)
 - Target all PHP source directories (NOT vendor)
 - Use `app/vendor/autoload.php` as bootstrap
 - Start at Level 5
+
+**Note:** `phpstan-symfony` is useful for recognizing Symfony attributes (`#[Route]`, `#[Assert\...]`) and HTTP Foundation types. It does NOT require a Symfony container XML dump — Pagekit uses its own PSR-11 container, not a standard Symfony container.
 
 ### 1.3. Run PHPStan and generate baseline
 
@@ -74,14 +82,16 @@ Adjust paths based on discovery. The config must:
 ./app/vendor/bin/phpstan analyse --generate-baseline
 ```
 
-This creates `phpstan-baseline.neon`. Add it to `phpstan.neon`:
+This creates `phpstan-baseline.neon`. Add it to the existing `includes` section in `phpstan.neon`:
 
 ```neon
 includes:
     - phpstan-baseline.neon
+    - app/vendor/phpstan/phpstan-doctrine/extension.neon
+    - app/vendor/phpstan/phpstan-symfony/extension.neon
 ```
 
-Document the number of baseline errors.
+Add a comment at the top of `phpstan-baseline.neon` with the total error count and date for future reference.
 
 ### 1.4. Verify PHPStan runs clean
 
@@ -113,11 +123,15 @@ composer require --dev friendsofphp/php-cs-fixer
 
 ### 3.2. Update `.php-cs-fixer.php`
 
-Change ruleset from `@PSR2` to `@PSR12`:
+**Two changes required:**
+
+1. Change ruleset from `@PSR2` to `@PSR12`:
 
 ```php
 '@PSR12' => true,  // was: '@PSR2' => true
 ```
+
+2. Remove `'packages'` from the `->exclude([...])` array in the Finder. The current config excludes `packages/` from formatting, but PHPStan analyzes it. Both tools should cover the same scope.
 
 **⚠️ Do NOT add `declare_strict_types` rule.** That comes in Step 2.1.3.
 
@@ -129,7 +143,7 @@ Keep all existing additional rules (array_syntax, ordered_imports, etc.).
 ./app/vendor/bin/php-cs-fixer fix
 ```
 
-This is formatting only — no semantic changes. Commit the formatting changes separately from tool installation.
+This is formatting only — no semantic changes.
 
 ### 3.4. Verify no regressions
 
@@ -141,8 +155,8 @@ This is formatting only — no semantic changes. Commit the formatting changes s
 
 ## 4. DOCUMENTATION
 
-Document baseline metrics:
-- PHPStan Level 5 baseline error count
+Include baseline metrics in the **PR description**:
+- PHPStan Level 5 baseline error count (also recorded as comment in `phpstan-baseline.neon`)
 - Number of PHP files analyzed
 - Code style changes applied (PSR-2 → PSR-12 diff summary)
 
@@ -150,10 +164,10 @@ Document baseline metrics:
 
 ## SUCCESS CRITERIA
 
-- PHPStan installed and runs at Level 5 with baseline
+- PHPStan installed and runs at Level 5 with baseline (Doctrine + Symfony extensions active)
 - `phpstan.neon` and `phpstan-baseline.neon` committed
 - `roave/security-advisories` installed
-- PHP-CS-Fixer upgraded to `@PSR12`
+- PHP-CS-Fixer upgraded to `@PSR12`, `packages` no longer excluded from formatting
 - Code formatted with PSR-12
 - No `declare(strict_types=1)` changes
 - All PHPUnit tests pass
@@ -162,10 +176,10 @@ Document baseline metrics:
 
 ## VALIDATION CHECKLIST
 
-- [ ] `phpstan.neon` exists and is valid
-- [ ] `phpstan-baseline.neon` exists
+- [ ] `phpstan.neon` exists and includes Doctrine + Symfony extension `.neon` files
+- [ ] `phpstan-baseline.neon` exists with error count comment
 - [ ] `./app/vendor/bin/phpstan analyse` passes (zero errors above baseline)
-- [ ] `.php-cs-fixer.php` uses `@PSR12`
+- [ ] `.php-cs-fixer.php` uses `@PSR12` and no longer excludes `packages`
 - [ ] `roave/security-advisories` in `composer.json`
-- [ ] All PHPUnit tests pass
+- [ ] All PHPUnit tests pass (~280 tests)
 - [ ] No `strict_types` changes

--- a/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/PROMPT_2_1_3_Strict-Types-Migration.md
+++ b/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/PROMPT_2_1_3_Strict-Types-Migration.md
@@ -8,7 +8,7 @@
 
 - **Depends on:** Step 2.1.2 (CI/CD — regressions caught immediately)
 - **Risk:** Medium-High — `strict_types` changes runtime behavior, can cause `TypeError`
-- **Current state:** ~135 of ~900 PHP files have `strict_types` (~15%). The rest are untyped.
+- **Current state:** ~137 of ~790 PHP files have `strict_types` (~17%). The rest are untyped.
 
 **Goal:** Add `declare(strict_types=1)` to ALL PHP files, module-by-module, fixing TypeErrors as they appear.
 

--- a/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/Static-Analysis-Overview.md
+++ b/migration-docs/TODO/agent_prompts/Step-2_1-Static-Analysis-and-Code-Quality-Tools/Static-Analysis-Overview.md
@@ -46,8 +46,8 @@ Use the **Task Invocation Template** (`.cursor/PROMPT_TASK_INVOCATION_TEMPLATE.m
 
 | Metric | Current | Target |
 |--------|---------|--------|
-| PHP files (excl. vendor) | ~900 | All modernized |
-| Files with `strict_types` | ~135 (~15%) | 100% |
+| PHP files (excl. vendor) | ~790 | All modernized |
+| Files with `strict_types` | ~137 (~17%) | 100% |
 | PHPStan | Not installed | Level 8 |
 | PHP-CS-Fixer config | `@PSR2` (`.php-cs-fixer.php`) | `@PSR12` |
 | CI/CD for PHP quality | None (only project automation) | Full pipeline |
@@ -68,4 +68,4 @@ Each sub-step creates its own branch. After merging into `develop`, the next sub
 - **Vendor directory is `app/vendor/`**, not `vendor/`. Binaries go to `app/vendor/bin/`.
 - **PHP-CS-Fixer** exists as `.php-cs-fixer.php` config but is NOT in `composer.json` as a dev dependency yet.
 - The `executeQuery()` method in Pagekit's QueryBuilder is currently **protected**, not public.
-- **~900 PHP files** need `strict_types` — this is NOT a trivial style change, it changes runtime behavior.
+- **~790 PHP files** need `strict_types` — this is NOT a trivial style change, it changes runtime behavior.

--- a/tests/e2e/COMPLETE_TEST_PLAN.md
+++ b/tests/e2e/COMPLETE_TEST_PLAN.md
@@ -2,7 +2,7 @@
 
 **Stand:** 12.02.2026 | **Version:** 2.2 | **System:** Pagekit Modernized
 
-**Abgleich:** Dieser Plan ist mit `migration-docs/TODO/MODERNISING_PAGEKIT_TODO_LIST.md` und `tests/e2e/TEST_PLAN_ANALYSIS_2025.md` abgestimmt. Features, die laut Roadmap erst in Phase 4/5 kommen oder aktuell nicht vorhanden sind, sind entsprechend gekennzeichnet.
+**Abgleich:** Dieser Plan ist mit der [ROADMAP](../../.cursor/ROADMAP.md) und `tests/e2e/TEST_PLAN_ANALYSIS_2025.md` abgestimmt. Features, die laut Roadmap erst in Phase 4/5 kommen oder aktuell nicht vorhanden sind, sind entsprechend gekennzeichnet.
 
 ---
 
@@ -10,7 +10,7 @@
 
 - **Nicht die komplette E2E-Suite bei jedem Schritt laufen lassen.**  
   Pro Modernisierungs-Schritt: **nur** Installationstest + die Specs der betroffenen Feature-Bereiche ausführen.  
-  Siehe `MODERNISING_PAGEKIT_TODO_LIST.md` → „Test-Driven Development (CRITICAL)“.
+  Siehe `AGENTS.md` → „Modernisation Workflow Rules“.
 - Vor Arbeit: `npx playwright test tests/e2e/specs/01-setup/installation.spec.js` + `./app/vendor/bin/phpunit`
 - Nach jedem Schritt: frische Installation + betroffene Feature-Tests + PHPUnit (alle grün vor PR).
 


### PR DESCRIPTION
## Summary

- Update stale file references (`MODERNISING_PAGEKIT_TODO_LIST.md` → `MODERNISATION_STRATEGY.md` / `ROADMAP.md`) across 3 files
- Restructure `migration-docs/README.md`: flat listings, archived Phase 1 sections, added tracking table with ROADMAP as SSOT
- Simplify feature-branch rule and tickets README to reference `push.mdc`
- Add current version/step header to ROADMAP and modernisation workflow note to AGENTS.md

## Test plan

- [x] All changes are documentation-only — no code, no tests affected
- [x] Verify links in migration-docs/README.md resolve correctly
- [x] Verify ROADMAP.md header shows correct version (1.2.5) and step (2.1)

<!-- metadata
labels: phase-2, documentation
milestone: Phase 2: Developer Experience
-->