### PR TITLE
chore: refresh composer.lock hash and roadmap formatting

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d44bfe123960f863e06a84a4a590ea77",
+    "content-hash": "d267ff218fd01e52cd18cfc2d7c01a3a",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/migration-docs/TODO/PHASE_2_MODERNISING.md
+++ b/migration-docs/TODO/PHASE_2_MODERNISING.md
@@ -120,7 +120,7 @@ Apply the aggressive modernization rules (defined during Phase 1 execution) retr
 - **Prerequisite**: Step 2.0.4 (Package/Migration System Redesign) completed
 - **Context**: Phase 1 Audit (Steps 1.3, 1.4) revealed several infrastructure issues that were not addressed during Phase 1 because they did not block functionality. With CI/CD coming in Step 2.2, these must be fixed first.
 - **Tasks**:
-  - **~~Lockfile versioning:~~** *(shipped early in Step 2.0.3, PR #187)*
+  - **~~Lockfile versioning:~~** (shipped early in Step 2.0.3, PR #187)
     - ~~Remove `/composer.lock` and `/yarn.lock` from `.gitignore`~~
     - ~~Commit `composer.lock` and `yarn.lock` for reproducible builds~~
     - ~~Rewrite `.cursor/install.sh` to use `composer install` (not `update`)~~


### PR DESCRIPTION
## Summary

Two small maintenance commits that surfaced during local work — no functional or dependency changes.

- **`docs(roadmap): drop italics on shipped lockfile note`** — Removed leftover italic markers (`*...*`) around the parenthetical "shipped early in Step 2.0.3, PR #187" in `migration-docs/TODO/PHASE_2_MODERNISING.md` for cleaner rendering.
- **`chore(deps): refresh composer.lock content-hash`** — Regenerates the `content-hash` field in `composer.lock`. No package versions or dependencies changed; only the hash itself was out of sync.

## Test plan

- [x] `git diff` confirms only the content-hash line changed in `composer.lock` (no package list changes)
- [x] Roadmap markdown renders correctly without stray asterisks
- [ ] CI green on `develop`

## Notes

Per request: no version bump and no `CHANGELOG-NEW.md` entry — these are pure housekeeping changes that do not warrant a release entry.

<!-- metadata
labels: phase-2, chore, documentation
milestone: Phase 2: Developer Experience
-->