### PR TITLE
chore(agents): update model assignments for orchestrator subagents

### DIFF
--- a/.cursor/agents/architect.md
+++ b/.cursor/agents/architect.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-model: claude-4.6-opus-max-thinking
+model: claude-opus-4-7
 description: Strategic Lead for Pagekit modernization. Maps task prompts to ROADMAP.md, defines scope, checklist, TODO-Spec. Use proactively when executing agent_prompts or task prompts from the modernization plan.
 ---
 

--- a/.cursor/agents/refactorer.md
+++ b/.cursor/agents/refactorer.md
@@ -1,6 +1,6 @@
 ---
 name: refactorer
-model: claude-4.6-opus-max-thinking
+model: claude-opus-4-7
 description: No Mercy Code Engineer for Pagekit modernization. Executes Architect's plan with direct replacement, no shims. Use when implementing refactoring steps from the Architect's checklist.
 ---
 

--- a/.cursor/agents/tester.md
+++ b/.cursor/agents/tester.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-model: claude-4.6-opus-high-thinking
+model: claude-sonnet-4-6
 description: Quality Guard for Pagekit modernization. Runs php pagekit setup, PHPUnit, Playwright. Performs RCA on failure. Use proactively after Verifier passes.
 ---
 

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,6 +1,6 @@
 ---
 name: verifier
-model: claude-4.6-opus-high-thinking
+model: claude-opus-4-6
 description: Quality Auditor for Pagekit modernization. Audits Refactorer output for No Mercy compliance and ROADMAP traceability. Use proactively after Refactorer completes a step.
 ---
 


### PR DESCRIPTION
## Summary

Updates the `model:` field in the four orchestrator subagent configs under `.cursor/agents/` to current model slugs.

| Agent       | Before                          | After                |
|-------------|---------------------------------|----------------------|
| architect   | `claude-4.6-opus-max-thinking`  | `claude-opus-4-7`    |
| refactorer  | `claude-4.6-opus-max-thinking`  | `claude-opus-4-7`    |
| verifier    | `claude-4.6-opus-high-thinking` | `claude-opus-4-6`    |
| tester      | `claude-4.6-opus-high-thinking` | `claude-sonnet-4-6`  |

No behavioral or prompt changes — only model selection. The tester is intentionally moved to Sonnet (cheaper, fast enough for test runs and RCA), while architect, refactorer and verifier stay on Opus for planning, refactoring and audit depth.

## Test plan

- [x] YAML frontmatter still valid in all four files
- [x] Only the `model:` line changed per file (verified via `git diff`)
- [ ] Next orchestrator run picks up the new models without errors

## Notes

Per request: no version bump and no `CHANGELOG-NEW.md` entry — agent config tweaks do not affect the shipped product.

<!-- metadata
labels: phase-2, chore, documentation
milestone: Phase 2: Developer Experience
-->