### PR TITLE
docs(orchestrator): require ROADMAP update incl. Phase 1 audit closures in finalize

### DIFF
--- a/.cursor/PROMPT_TASK_INVOCATION_TEMPLATE.md
+++ b/.cursor/PROMPT_TASK_INVOCATION_TEMPLATE.md
@@ -31,7 +31,7 @@ Rules:
 - One step at a time (sequential)
 - Commit per completed step (Conventional Commits)
 - Do NOT batch commits until end of task
-- After last step: create branch documentation in migration-docs/branches/{task-name}.md, then follow push.mdc (version bump → CHANGELOG → push → PR with metadata). PR must include "Closes #XXX" and the issue number in the metadata block. Do NOT merge.
+- After last step: create branch documentation in migration-docs/branches/{task-name}.md, then follow push.mdc (version bump → CHANGELOG → ROADMAP update incl. Phase 1 audit closures → push → PR with metadata). PR must include "Closes #XXX" and the issue number in the metadata block. Do NOT merge.
 
 Token discipline (Orchestrator):
 - Delegate to Architect immediately. Do NOT read the full task prompt or ROADMAP yourself.

--- a/.cursor/rules/push.mdc
+++ b/.cursor/rules/push.mdc
@@ -1,5 +1,5 @@
 ---
-description: Push workflow with version bump. 1) Check git status, create smart commits (conventional-commits.mdc). 2) Use version-bump skill → update app/system/config.php (version is no longer stored in composer.json). 3) Update CHANGELOG-NEW.md; commit "chore(release): bump version to X.Y.Z". 4) If README-affected → readme-sync.mdc. 5) Push: develop (protected) → new branch + PR; other branch → push direct. 6) PR metadata: include <!-- metadata --> block with labels, milestone, and Closes #X. 7) Do not merge.
+description: Push workflow with version bump. 1) Check git status, create smart commits (conventional-commits.mdc). 2) Use version-bump skill → update app/system/config.php (version is no longer stored in composer.json). 3) Update CHANGELOG-NEW.md; commit "chore(release): bump version to X.Y.Z". 4) Update .cursor/ROADMAP.md (header pointer + step row + Phase 1 audit closures from "Closes Phase 1 audit:" lines; skip partial closures); commit "docs(roadmap): …". 5) If README-affected → readme-sync.mdc. 6) Push: develop (protected) → new branch + PR; other branch → push direct. 7) PR metadata: include <!-- metadata --> block with labels, milestone, and Closes #X. 8) Do not merge.
 alwaysApply: false
 ---
 
@@ -8,11 +8,16 @@ alwaysApply: false
 1. **Check git status** – create commits (see `conventional-commits.mdc`)
 2. **Version Bump** – use `.cursor/skills/version-bump/SKILL.md`
 3. **CHANGELOG-NEW.md** – new section with version + date + grouped commits; commit: `chore(release): bump version to X.Y.Z`
-4. **README Sync** – if relevant files changed (see `readme-sync.mdc`)
-5. **Push**:
+4. **ROADMAP Update** – update `.cursor/ROADMAP.md`:
+   - **Header**: bump `Current Version` and advance `Current Step` pointer to the next step
+   - **This step's tracking row**: Status `⏳` → `✅`, Audit `⏳` → `🛡️`, PR `-` → `#YYY`
+   - **Phase 1 audit closures**: check the `Closes Phase 1 audit:` line in the task prompt header AND in `PHASE_2_MODERNISING.md` for the step that was just executed. For each `1.X` listed there, flip the corresponding row's Audit column `⚠️` → `🛡️`. **Skip** rows tagged `(partial)` or `requires also Step Y` until the dependency has also landed.
+   - Commit: `docs(roadmap): close Step X.Y.Z + Phase 1 audit M.N` (or simply `docs(roadmap): close Step X.Y.Z` if no Phase 1 audit row is affected)
+5. **README Sync** – if relevant files changed (see `readme-sync.mdc`)
+6. **Push**:
    - On `develop` (protected) → create new branch (CC-style name), push, create/update PR
    - On any other branch → push directly
-6. **PR Metadata** – every PR body MUST end with a `<!-- metadata -->` block.
+7. **PR Metadata** – every PR body MUST end with a `<!-- metadata -->` block.
    `sync-metadata.yml` automatically applies labels + milestone from this block.
    ```markdown
    <!-- metadata
@@ -24,4 +29,4 @@ alwaysApply: false
    - **labels**: 1 phase + 1 type + 1-2 area labels (see `github-labels.mdc`)
    - **milestone**: Phase name (shorthand `Phase 1` or full `Phase 1: Foundation`)
    - **closes**: related GitHub Issues — also include `Closes #X` in visible PR body text for GitHub's auto-close linking
-7. **Do NOT merge** – user merges after CI/tests pass
+8. **Do NOT merge** – user merges after CI/tests pass


### PR DESCRIPTION
## Summary

Fixes a recurring miss in the Orchestrator finalize workflow: forgetting to flip Phase 1 audit rows in `.cursor/ROADMAP.md` when a Foundation Consolidation or Static Analysis sub-step closes a documented Phase 1 finding. During Steps 2.0.5–2.0.7 this directly caused several follow-up `docs(roadmap):` correction commits (missed flips for **1.2 / 1.4 / 1.7 / 1.8 / 1.13**).

The previous wording in the task invocation template was simply "Update the ROADMAP.md if needed" — too vague for an LLM-driven finalize step to act on reliably.

## Changes

### `.cursor/rules/push.mdc` — new Step 4 "ROADMAP Update"

Inserted between the CHANGELOG-NEW.md commit (Step 3) and README sync (Step 5, previously 4). Subsequent steps renumbered 5→6, 6→7, 7→8. The new step explicitly lists:

- **Header:** bump `Current Version` and advance `Current Step` pointer
- **This step's tracking row:** Status `⏳` → `✅`, Audit `⏳` → `🛡️`, PR `-` → `#YYY`
- **Phase 1 audit closures:** check the `Closes Phase 1 audit:` line in the task prompt header AND in `PHASE_2_MODERNISING.md`. Flip each listed `1.X` row's Audit column `⚠️` → `🛡️`. **Skip** rows tagged `(partial)` or `requires also Step Y` until the dependency lands.
- **Commit convention:** `docs(roadmap): close Step X.Y.Z + Phase 1 audit M.N` (or just `docs(roadmap): close Step X.Y.Z` if no Phase 1 row is touched)

Frontmatter `description:` field updated in lockstep.

### `.cursor/PROMPT_TASK_INVOCATION_TEMPLATE.md` — finalize line tightened

The "After last step" line now reads:

> `…then follow push.mdc (version bump → CHANGELOG → **ROADMAP update incl. Phase 1 audit closures** → push → PR with metadata)…`

The detailed checklist lives only in `push.mdc` — no duplication.

## Why this works

The `Closes Phase 1 audit:` annotations were added to all relevant 2.0.x / 2.1.x sections in `PHASE_2_MODERNISING.md` (`e203a852` on PR #195) and to `PROMPT_2_0_8`'s header (`45b9f93c` on PR #195). With both data sources in place, the Orchestrator can mechanically derive the audit-row flips from the task definition without further human intervention. The new push.mdc step exists to make sure the Orchestrator actually consults those sources before opening the PR.

## Edge cases handled

- **Partial closures.** Step 2.0.8 closes only the User-model portion of 1.11; full 1.11 also requires 2.1.6. The new wording explicitly says "skip rows tagged `(partial)` or `requires also Step Y`" so the Orchestrator doesn't prematurely flip 1.11 after 2.0.8 alone.
- **No Phase 1 audit closure.** Steps that don't close any Phase 1 finding (e.g. 2.1.1 Tooling Setup) still go through Step 4 — they just won't have an extra `1.X` flip, and the commit subject becomes the simpler `docs(roadmap): close Step X.Y.Z`.
- **Header-only updates.** Even if no audit row changes, `Current Version` and `Current Step` pointer always need to advance after a step lands.

## Test plan

- [x] Read top-level frontmatter of `.cursor/rules/push.mdc` — Step 4 mentioned in description, all 8 numbered steps consistent with body.
- [x] Read `.cursor/PROMPT_TASK_INVOCATION_TEMPLATE.md` Zeile 34 — references `ROADMAP update incl. Phase 1 audit closures` and points to `push.mdc` for details.
- [x] Apply the new workflow to a small docs-only run on a future step (e.g. 2.0.8 finalize) and verify the Orchestrator opens the ROADMAP update commit before pushing.

## References

- Existing Phase 1 audit annotations: `migration-docs/TODO/PHASE_2_MODERNISING.md` (every 2.0.x / 2.1.x section that closes a Phase 1 finding)
- Existing prompt-header annotation pattern: `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_8_User-hasAccess-Hotfix.md` (`Closes Phase 1 audit (partial):` line in the header)
- Recent corrections that this PR prevents from recurring: `7a62e8af` (1.2 / 1.4 / 1.8 follow-up on PR #193), `7b290ae8` (1.7 + 2.0.7 follow-up on PR #195), `82f2cf6e` (1.13 follow-up on PR #195)

<!-- metadata
labels: phase-2, documentation
milestone: Phase 2: Developer Experience
-->
