### PR TITLE
fix(user): Step 2.0.8 — replace create_function() in User::hasAccess()

### DIFF
--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,7 +1,7 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
 > **Current Version**: 1.2.13
-> **Current Step**: 2.1.2 (CI/CD Integration & Quality Gates)
+> **Current Step**: 2.0 (Foundation Consolidation — Closure & Gap Audit)
 
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**
 

--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,7 +1,7 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
-> **Current Version**: 1.2.12
-> **Current Step**: 2.0.8 (Hotfix: `create_function()` in User)
+> **Current Version**: 1.2.13
+> **Current Step**: 2.1.2 (CI/CD Integration & Quality Gates)
 
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**
 
@@ -74,7 +74,7 @@
 | 2.0.5  | ↳ Composer & Autoload Hygiene         | ✅     | 🛡️    | #182  | #192    |
 | 2.0.6  | ↳ Test Infrastructure Cleanup         | ✅     | 🛡️    | #183  | #193    |
 | 2.0.7  | ↳ Event Dispatcher Bridge Removal     | ✅     | 🛡️    | #184  | #195    |
-| 2.0.8  | ↳ Hotfix: `create_function()` in User | ⏳     | ⏳    | #185  | -       |
+| 2.0.8  | ↳ Hotfix: `create_function()` in User | ✅     | 🛡️    | #185  | #197    |
 | 2.1    | **Static Analysis & Code Quality**    | ⏳     | ⏳    | #147  | -       |
 | 2.1.1  | ↳ Tooling-Setup & Baseline            | ✅     | ⏳    | #148  | #178    |
 | 2.1.2  | ↳ CI/CD Integration & Quality Gates   | ⏳     | ⏳    | #149  | -       |

--- a/.cursor/tickets/PROMPT_2_0_8_User-hasAccess-Hotfix_plan.md
+++ b/.cursor/tickets/PROMPT_2_0_8_User-hasAccess-Hotfix_plan.md
@@ -1,0 +1,111 @@
+## ARCHITECT OUTPUT
+- **Current Step (ROADMAP):** 2.0.8 (Hotfix: `create_function()` in `User::hasAccess()`)
+- **Scope:**
+  - `app/system/modules/user/src/Model/User.php` — replace the `create_function()`-based evaluator inside `hasAccess()` (~lines 209–228) with a safe boolean-expression evaluator. Preserve the existing two short-circuits (administrator / empty / single-permission) and the regex reduction to a `0/1/&/|/!/()` string. Add a private static method `evaluateBooleanExpression(string $exp): bool` (recursive descent parser) on the same class. Strict types stay enabled (file already has `declare(strict_types=1);`).
+  - `app/system/modules/user/src/Tests/UserAccessTest.php` — **new file**. Unit tests for the boolean evaluator (via `\ReflectionMethod` since the method is `private static`) AND for composite expressions in `hasAccess()` using a small `User` test fixture / partial mock with deterministic `hasPermission()` and `isAdministrator()` behaviour. Test directory matches the existing convention used by `mail` / `intl` / `cache` modules and is already covered by the root `phpunit.xml.dist` glob `app/system/modules/*/src/Tests`.
+- **Deferred:**
+  - Step 2.1.6 (PHPStan Level 7→8) — the rest of the Phase 1 §1.11 ORM-modernization audit findings (`EntityManager` singleton, `ModelServiceLocator` / `IntlServiceLocator` static service locators, ORM `Metadata` / `Relation` / `PropertyTrait` typing gaps, `#[AllowDynamicProperties]` on `Node` / `Widget`). Do **not** flip the §1.11 ROADMAP audit cell from ⚠️ to 🛡️ at the end of this ticket — it stays ⚠️ until 2.1.6 also lands.
+  - Step 2.1.3 (`strict_types` Migration) — only `User.php` is touched here, and it already declares strict types; no other files need a `declare(strict_types=1);` audit as part of this ticket.
+  - Step 4.1 (Basic Security) / Step 1.13.5 (CSP) — `eval()` and any other code-execution mechanism are explicitly forbidden as the replacement; this ticket already enforces that.
+  - Refactoring `User::hasAccess()` into a separate `PermissionExpressionEvaluator` service / class — out of scope. Per Rule 1 (NO COMPATIBILITY LAYERS) and Rule 2 (NO ADAPTERS), the helper stays a `private static` method on `User` since it has exactly one caller. If a future step (e.g., 2.5 Extension Safety System) needs to share it, the extraction belongs there.
+- **Bridges:** None.
+  - Rule 4 (DELETE OVER WRAP): the `create_function()` line is **physically deleted** from `User::hasAccess()` (not commented out, not toggled by a feature flag, not kept behind a PHP-version check).
+  - Rule 1 (NO COMPATIBILITY LAYERS): no `eval()`, no `Closure::fromCallable`, no `assert()`, no `ExpressionLanguage` dependency. The only acceptable replacement is the recursive-descent parser specified in the prompt §3.2.
+  - Rule 2 (NO ADAPTERS): no separate "evaluator service" class, no helper trait, no facade — one `private static` method on `User`, called exactly once by `hasAccess()`.
+  - Rule 5 (MANDATORY FLAGGING): no temporary-bridge TODOs are introduced. If, during refactoring, an unavoidable hack is needed it MUST use ROADMAP IDs only:
+    - `// TODO: AUDIT FIX Step 2.0.8 (User::hasAccess Hotfix)` — fallback marker for a non-trivial fix surfaced during this step.
+    - `// TODO: Must be refactored in Step 2.1.6 (PHPStan Level 8)` — only if a typing gap that 2.1.6 will close blocks the patch.
+- **Checklist:** see below.
+
+## Checklist
+
+1. **Pre-flight baseline & scope confirmation**
+   - Capture green baseline before any code change:
+     - `./app/vendor/bin/phpunit`
+     - `./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
+     - `php pagekit list`
+   - Pre-existing red is a blocker — escalate to architect. Do not proceed otherwise.
+   - Confirm the ONLY occurrence of `create_function` in the codebase is in `User.php`:
+     - `rg -n "create_function" app/ packages/ --glob "*.php"`
+     - Expected: exactly one hit at `app/system/modules/user/src/Model/User.php`.
+   - Confirm the test directory pattern is wired into the root config:
+     - `rg -n "system/modules/\*/src/Tests" phpunit.xml.dist` — must show the include line.
+   - No code changes in this step.
+
+2. **Add `evaluateBooleanExpression()` to `User.php`**
+   - Edit only `app/system/modules/user/src/Model/User.php`.
+   - Add a new `private static function evaluateBooleanExpression(string $exp): bool` method at the bottom of the class, just before `jsonSerialize()` (or after `hasAccess()`, whichever keeps the existing method ordering tidy).
+   - Implement the recursive-descent parser exactly as specified in the prompt §3.2:
+     - Grammar: `expr → orExpr` | `orExpr → andExpr ( ('||' | '|') andExpr )*` | `andExpr → notExpr ( ('&&' | '&') notExpr )*` | `notExpr → '!' notExpr | atom` | `atom → '(' expr ')' | '0' | '1'`.
+     - Operator precedence: `!` > `&&` > `||`.
+     - Both single (`&`, `|`) and double (`&&`, `||`) operators MUST be accepted (the upstream sanitization regex preserves single operators; failing to handle them would silently break existing call sites).
+     - Pure-PHP, no `eval()`, no `Closure::fromCallable`, no `assert()`, no `ExpressionLanguage` dependency, no other code-execution primitive.
+   - Do **NOT** call this method from `hasAccess()` yet — keep the change isolated.
+   - Per-step gate (mandatory): PHPUnit + PHPStan. Both must stay green; the new method is unused so PHPStan may flag it as dead code only if the project has `deadCode` rules enabled (currently it does not, per the existing baseline). If PHPStan complains, address the warning in this step before moving on.
+
+3. **Wire `hasAccess()` to the new evaluator and delete `create_function`**
+   - Same file: `app/system/modules/user/src/Model/User.php`.
+   - Replace the entire `create_function`-based block (currently lines ~223–227) with:
+     ```php
+     try {
+         return self::evaluateBooleanExpression($exp);
+     } catch (\Throwable) {
+         throw new \InvalidArgumentException(
+             sprintf('Unable to parse the given access string "%s"', $expression)
+         );
+     }
+     ```
+   - Per Rule 4: physically delete the `if (!$fn = @create_function(...))` line and the `return (bool) $fn();` line. Do not comment them out.
+   - Preserve the unchanged early-exit logic (`isAdministrator() || empty($expression)`), the simple-permission short-circuit (`!preg_match('/[&\(\)\|\!]/', $expression)`), and the existing regex reduction that produces `$exp`.
+   - Do not introduce any new TODO markers unless something genuinely cannot be resolved here; if so, use the ROADMAP-ID format from the Bridges section above.
+   - Per-step gate (mandatory): PHPUnit + PHPStan. Existing PHPUnit suite must remain green. The new evaluator is now reachable via `hasAccess()`, so static analysis must still pass.
+
+4. **Verify `create_function` is fully eradicated from the codebase**
+   - Run: `rg -n "create_function" app/ packages/ --glob "*.php"`.
+   - Expected: **zero hits**. If any remain (vendor excluded — `app/vendor` is composer-managed), fix them in this same step rather than deferring.
+   - Run: `rg -n "create_function" app/vendor --glob "*.php"` for awareness only — vendor hits are out of scope but should be noted in the commit message if present (no fix in vendor; that is dependency-update territory).
+   - Per-step gate (mandatory): PHPUnit + PHPStan.
+
+5. **Add unit tests for the evaluator and `hasAccess()` composite expressions**
+   - New file: `app/system/modules/user/src/Tests/UserAccessTest.php`.
+   - File MUST start with `<?php` and `declare(strict_types=1);`, namespace `Pagekit\User\Tests`, extend `PHPUnit\Framework\TestCase`.
+   - **Section A — Pure evaluator tests** (use `\ReflectionMethod` to invoke the `private static` `evaluateBooleanExpression`):
+     - `'1'` → true, `'0'` → false
+     - `'1&&1'` → true, `'1&&0'` → false
+     - `'0||1'` → true, `'0||0'` → false
+     - `'1&1'` → true, `'1&0'` → false (single-operator `&` MUST behave like `&&`)
+     - `'0|1'` → true, `'0|0'` → false (single-operator `|` MUST behave like `||`)
+     - `'!0'` → true, `'!1'` → false
+     - `'(1&&0)||1'` → true, `'(0||0)&&1'` → false
+     - Operator precedence: `'1||0&&0'` → true (must NOT collapse to `(1||0)&&0`)
+     - Nested: `'!(0||(1&&!1))'` → true
+   - **Section B — `hasAccess()` integration tests** (use a small fixture: a `User` subclass or partially-mocked instance that overrides `isAdministrator()` (returns `false`) and `hasPermission()` to return `true` for `read` and `write`, `false` for everything else; alternatively use the PHPUnit mocking API with `getMockBuilder(User::class)->onlyMethods(['isAdministrator', 'hasPermission'])`). Cover **at minimum** every assertion from prompt §4.1:
+     - Simple: `$user->hasAccess('read')` → true; `$user->hasAccess('admin')` → false
+     - AND double: `'read && write'` → true; `'read && admin'` → false
+     - AND single: `'read & write'` → true; `'read & admin'` → false
+     - OR double: `'read || admin'` → true; `'admin || superadmin'` → false
+     - OR single: `'read | admin'` → true; `'admin | superadmin'` → false
+     - NOT: `'!admin'` → true; `'!read'` → false
+     - Parentheses: `'(read && write) || admin'` → true; `'(admin && write) || superadmin'` → false
+     - Nested: `'read && (write || admin)'` → true; `'admin && (write || read)'` → false
+     - Complex: `'(read || admin) && (write || superadmin)'` → true
+     - Empty / null: `$user->hasAccess('')` → true; `$user->hasAccess(null)` → true
+     - Administrator short-circuit: a fixture with `isAdministrator()` returning `true` and **zero** permissions returns `true` for any expression including `'admin && write'`.
+     - Invalid expression: `$user->hasAccess('&&& invalid')` throws `\InvalidArgumentException` (use `expectException` or a separate test method).
+   - Tests MUST NOT bootstrap the full Pagekit application (no DB, no container, no kernel); the `User` model fixture / mock approach keeps them pure unit tests so they run in the existing PHPUnit suite without new fixtures.
+   - If the chosen fixture approach exposes a typing or mocking issue (e.g., `findRoles()` static call from the `hasPermission()` body), the test MUST mock `hasPermission()` itself rather than reaching into `findRoles` — keep tests narrow.
+   - Per-step gate (mandatory): PHPUnit + PHPStan. The new test file participates in PHPStan analysis (the root config includes `app/system`); fix any complaints in this step.
+
+6. **Final consolidated audit (mirrors prompt §5 + §6)**
+   - `rg -n "create_function" app/ packages/ --glob "*.php"` → zero hits.
+   - `rg -n "eval\s*\(" app/system/modules/user/src/Model/User.php` → zero hits (sanity check that the replacement did not regress).
+   - `./app/vendor/bin/phpunit` — green; the new `UserAccessTest` cases all run and pass.
+   - `./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M` — green.
+   - `php pagekit list` — green (no fatal at boot; the change touches authorization which the console bootstraps).
+   - `php pagekit setup` — clean (final-run only, not per-step).
+   - Playwright E2E (installation, login, dashboard) — green (final-run only, not per-step). Login exercises the authorization stack and is the closest production-shaped smoke test for `hasAccess()`.
+   - Confirm `.cursor/ROADMAP.md` §1.11 audit cell stays ⚠️ (do **not** flip to 🛡️ — that requires Step 2.1.6 to also land, per the prompt's "Closes Phase 1 audit (partial)" note).
+
+## TESTING STRATEGY
+- **Per step:** PHPUnit + PHPStan (mandatory after every checklist step)
+- **Final run (after all steps):** PHPUnit + PHPStan + `php pagekit setup` + `php pagekit list` + Playwright E2E (installation, login, dashboard)

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Pagekit 1.2.13 - User::hasAccess() Hotfix (April 27, 2026)
+## Pagekit 1.2.13 - User::hasAccess() Hotfix (April 28, 2026)
 
 ### Fix
 

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Pagekit 1.2.13 - User::hasAccess() Hotfix (April 27, 2026)
+
+### Fix
+
+- **`create_function()` removed from `User::hasAccess()`** — The legacy `create_function()`-based boolean evaluator inside `app/system/modules/user/src/Model/User.php` is replaced by a safe, pure-PHP recursive-descent parser. `create_function()` was deprecated in PHP 7.2 and removed in PHP 8.0; the previous code would have produced a fatal error on every non-trivial permission check (anything containing `&`, `|`, `(`, `)`, or `!`). The new evaluator is a `private static evaluateBooleanExpression(string $exp): bool` method on the same class, accepts both single (`&`, `|`) and double (`&&`, `||`) operators plus `!` and parentheses, and enforces correct precedence (`!` > `&&` > `||`). No `eval()`, no `Closure::fromCallable`, no `assert()`, no Symfony `ExpressionLanguage` dependency. Invalid expressions now raise `\InvalidArgumentException` (previously the bug surfaced as a fatal `Call to undefined function create_function()`). (Closes #185)
+
+### Refactor
+
+- **`hasAccess()` simplified** — The `if (!$fn = @create_function('', "return …;")) { throw … } return (bool) $fn();` block is physically deleted (no shim, no adapter, no compatibility flag) per the modernization "DELETE OVER WRAP" rule. The early-exit logic (administrator short-circuit, empty expression, single-permission short-circuit) and the existing regex reduction that produces the `0/1/&/|/!/()` string are unchanged.
+
+### Chore
+
+- **`phpstan-baseline.neon` baseline trimmed** — The now-stale `Function create_function not found.` ignore entry scoped to `app/system/modules/user/src/Model/User.php` is removed, since the call site no longer exists. Baseline stays internally consistent: zero "ignored error not matched" warnings.
+
+### Tests
+
+- **New test file `app/system/modules/user/src/Tests/UserAccessTest.php`** — 37 test cases (765 assertions in the suite total). Section A exercises the pure evaluator via `\ReflectionMethod` (literals, AND/OR with both single and double operators, NOT, parentheses, precedence, nested expressions). Section B covers `User::hasAccess()` end-to-end via partial PHPUnit mocks for `isAdministrator()` and `hasPermission()` — simple permissions, AND/OR (single + double), NOT, parentheses, nested, complex composites, empty/null short-circuit, administrator override, and the `\InvalidArgumentException` path on parse failure. Tests are pure unit tests; no DB, no container, no Pagekit kernel bootstrap.
+- All **326 PHPUnit tests green** (was 289 before this step), 0 failures. PHPStan clean against the trimmed baseline (`[OK] No errors`).
+- `php pagekit setup` and `php pagekit list` successful.
+- Playwright E2E (chromium-only per `AGENTS.md`): `installation.spec.js` (1/1), `authentication.spec.js` (14/14), `dashboard.spec.js` (10/10) — all green; the login flow is the closest production-shaped smoke test for the authorization stack.
+
+### Internal
+
+- **Step 2.0.8 (User::hasAccess() Hotfix)** marked complete in `.cursor/ROADMAP.md`; Current Step pointer advances to the next foundation step.
+- **Phase 1 audit closure (partial)** — Phase 1 §1.11 (ORM modernization) audit cell stays ⚠️; the remaining findings (`EntityManager` singleton, `ModelServiceLocator` / `IntlServiceLocator` static service locators, ORM `Metadata` / `Relation` / `PropertyTrait` typing gaps, `#[AllowDynamicProperties]` on `Node` / `Widget`) are deferred to Step 2.1.6 (PHPStan Level 7→8) per the task prompt's "Closes Phase 1 audit (partial)" annotation.
+- **No-Mercy compliance:** physical deletion of the `create_function()` block, no shims, no adapters, no `@deprecated` markers, no new in-code TODOs. Aggressive Rules 1, 2, 4, 5 enforced.
+
+---
+
 ## Pagekit 1.2.12 - Event Dispatcher Bridge Removal (April 27, 2026)
 
 ### Breaking Changes (Internal)

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.2.12',
+        'version' => '1.2.13',
 
     ],
 

--- a/app/system/modules/user/src/Model/User.php
+++ b/app/system/modules/user/src/Model/User.php
@@ -220,11 +220,117 @@ class User implements UserInterface, \JsonSerializable
 
         $exp = preg_replace('/[^01&\(\)\|!]/', '', preg_replace_callback('/[a-z_][a-z-_\.:\d\s]*/i', fn ($permission) => (int) $user->hasPermission(trim($permission[0])), $expression));
 
-        if (!$fn = @create_function("", "return $exp;")) {
-            throw new \InvalidArgumentException(sprintf('Unable to parse the given access string "%s"', $expression));
+        try {
+            return self::evaluateBooleanExpression((string) $exp);
+        } catch (\Throwable) {
+            throw new \InvalidArgumentException(
+                sprintf('Unable to parse the given access string "%s"', $expression)
+            );
+        }
+    }
+
+    /**
+     * Evaluate a sanitized boolean expression composed of `0`, `1`, `&`, `&&`,
+     * `|`, `||`, `!` and parentheses using a recursive-descent parser.
+     *
+     * Replaces the legacy `create_function()` based evaluator. Pure PHP — no
+     * `eval()`, no `Closure::fromCallable`, no `assert()`, no
+     * `ExpressionLanguage` dependency.
+     *
+     * Grammar:
+     *   expr    -> orExpr
+     *   orExpr  -> andExpr ( ( '||' | '|' ) andExpr )*
+     *   andExpr -> notExpr ( ( '&&' | '&' ) notExpr )*
+     *   notExpr -> '!' notExpr | atom
+     *   atom    -> '(' expr ')' | '0' | '1'
+     *
+     * Precedence: `!` > `&&` > `||`.
+     *
+     * @throws \InvalidArgumentException on malformed input.
+     */
+    private static function evaluateBooleanExpression(string $exp): bool
+    {
+        $pos = 0;
+        $len = strlen($exp);
+
+        $result = self::parseOrExpr($exp, $len, $pos);
+
+        if ($pos !== $len) {
+            throw new \InvalidArgumentException(sprintf('Unexpected trailing input at position %d', $pos));
         }
 
-        return (bool) $fn();
+        return $result;
+    }
+
+    private static function parseOrExpr(string $exp, int $len, int &$pos): bool
+    {
+        $left = self::parseAndExpr($exp, $len, $pos);
+
+        while ($pos < $len && $exp[$pos] === '|') {
+            $pos++;
+            if ($pos < $len && $exp[$pos] === '|') {
+                $pos++;
+            }
+            $right = self::parseAndExpr($exp, $len, $pos);
+            $left = $left || $right;
+        }
+
+        return $left;
+    }
+
+    private static function parseAndExpr(string $exp, int $len, int &$pos): bool
+    {
+        $left = self::parseNotExpr($exp, $len, $pos);
+
+        while ($pos < $len && $exp[$pos] === '&') {
+            $pos++;
+            if ($pos < $len && $exp[$pos] === '&') {
+                $pos++;
+            }
+            $right = self::parseNotExpr($exp, $len, $pos);
+            $left = $left && $right;
+        }
+
+        return $left;
+    }
+
+    private static function parseNotExpr(string $exp, int $len, int &$pos): bool
+    {
+        if ($pos < $len && $exp[$pos] === '!') {
+            $pos++;
+
+            return !self::parseNotExpr($exp, $len, $pos);
+        }
+
+        return self::parseAtom($exp, $len, $pos);
+    }
+
+    private static function parseAtom(string $exp, int $len, int &$pos): bool
+    {
+        if ($pos >= $len) {
+            throw new \InvalidArgumentException('Unexpected end of expression');
+        }
+
+        $ch = $exp[$pos];
+
+        if ($ch === '(') {
+            $pos++;
+            $value = self::parseOrExpr($exp, $len, $pos);
+            if ($pos >= $len || $exp[$pos] !== ')') {
+                throw new \InvalidArgumentException('Missing closing parenthesis');
+            }
+            $pos++;
+
+            return $value;
+        }
+
+        if ($ch === '0' || $ch === '1') {
+            $pos++;
+
+            return $ch === '1';
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unexpected character "%s" at position %d', $ch, $pos));
     }
 
     /**

--- a/app/system/modules/user/src/Tests/UserAccessTest.php
+++ b/app/system/modules/user/src/Tests/UserAccessTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pagekit\User\Tests;
+
+use Pagekit\User\Model\User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the boolean expression evaluator and `User::hasAccess()`.
+ *
+ * Section A exercises the private static `evaluateBooleanExpression()` parser
+ * directly via Reflection. Section B exercises `hasAccess()` with a partial
+ * mock of `User` that stubs `isAdministrator()` and `hasPermission()` so the
+ * tests stay pure unit tests (no DB, no kernel, no container).
+ */
+class UserAccessTest extends TestCase
+{
+    /**
+     * Invoke the private static `evaluateBooleanExpression()` via Reflection.
+     */
+    private function evaluate(string $exp): bool
+    {
+        $method = new \ReflectionMethod(User::class, 'evaluateBooleanExpression');
+
+        return (bool) $method->invoke(null, $exp);
+    }
+
+    /**
+     * Build a partial mock of `User` with deterministic authorization stubs.
+     *
+     * @param array<string, bool> $permissions Map of permission name => granted.
+     */
+    private function buildUser(bool $isAdministrator, array $permissions): User
+    {
+        $mock = $this->getMockBuilder(User::class)
+            ->onlyMethods(['isAdministrator', 'hasPermission'])
+            ->getMock();
+
+        $mock->method('isAdministrator')->willReturn($isAdministrator);
+        $mock->method('hasPermission')->willReturnCallback(
+            static fn (string $permission): bool => $permissions[$permission] ?? false
+        );
+
+        return $mock;
+    }
+
+    // -----------------------------------------------------------------------
+    // Section A: pure evaluator tests (private static via Reflection).
+    // -----------------------------------------------------------------------
+
+    public function testEvaluatorLiteralOne(): void
+    {
+        $this->assertTrue($this->evaluate('1'));
+    }
+
+    public function testEvaluatorLiteralZero(): void
+    {
+        $this->assertFalse($this->evaluate('0'));
+    }
+
+    public function testEvaluatorAndDoubleTrue(): void
+    {
+        $this->assertTrue($this->evaluate('1&&1'));
+    }
+
+    public function testEvaluatorAndDoubleFalse(): void
+    {
+        $this->assertFalse($this->evaluate('1&&0'));
+    }
+
+    public function testEvaluatorOrDoubleTrue(): void
+    {
+        $this->assertTrue($this->evaluate('0||1'));
+    }
+
+    public function testEvaluatorOrDoubleFalse(): void
+    {
+        $this->assertFalse($this->evaluate('0||0'));
+    }
+
+    public function testEvaluatorAndSingleTrue(): void
+    {
+        $this->assertTrue($this->evaluate('1&1'));
+    }
+
+    public function testEvaluatorAndSingleFalse(): void
+    {
+        $this->assertFalse($this->evaluate('1&0'));
+    }
+
+    public function testEvaluatorOrSingleTrue(): void
+    {
+        $this->assertTrue($this->evaluate('0|1'));
+    }
+
+    public function testEvaluatorOrSingleFalse(): void
+    {
+        $this->assertFalse($this->evaluate('0|0'));
+    }
+
+    public function testEvaluatorNotZero(): void
+    {
+        $this->assertTrue($this->evaluate('!0'));
+    }
+
+    public function testEvaluatorNotOne(): void
+    {
+        $this->assertFalse($this->evaluate('!1'));
+    }
+
+    public function testEvaluatorParenthesesOrTrue(): void
+    {
+        $this->assertTrue($this->evaluate('(1&&0)||1'));
+    }
+
+    public function testEvaluatorParenthesesAndFalse(): void
+    {
+        $this->assertFalse($this->evaluate('(0||0)&&1'));
+    }
+
+    /**
+     * `&&` binds tighter than `||`. `1||0&&0` must parse as `1 || (0 && 0)`,
+     * not `(1 || 0) && 0`.
+     */
+    public function testEvaluatorOperatorPrecedence(): void
+    {
+        $this->assertTrue($this->evaluate('1||0&&0'));
+    }
+
+    public function testEvaluatorNestedNotAndOr(): void
+    {
+        $this->assertTrue($this->evaluate('!(0||(1&&!1))'));
+    }
+
+    // -----------------------------------------------------------------------
+    // Section B: `hasAccess()` integration tests (partial mock).
+    // -----------------------------------------------------------------------
+
+    public function testHasAccessSimpleGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read'));
+    }
+
+    public function testHasAccessSimpleDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('admin'));
+    }
+
+    public function testHasAccessAndDoubleGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read && write'));
+    }
+
+    public function testHasAccessAndDoubleDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('read && admin'));
+    }
+
+    public function testHasAccessAndSingleGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read & write'));
+    }
+
+    public function testHasAccessAndSingleDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('read & admin'));
+    }
+
+    public function testHasAccessOrDoubleGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read || admin'));
+    }
+
+    public function testHasAccessOrDoubleDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('admin || superadmin'));
+    }
+
+    public function testHasAccessOrSingleGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read | admin'));
+    }
+
+    public function testHasAccessOrSingleDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('admin | superadmin'));
+    }
+
+    public function testHasAccessNotGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('!admin'));
+    }
+
+    public function testHasAccessNotDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('!read'));
+    }
+
+    public function testHasAccessParenthesesGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('(read && write) || admin'));
+    }
+
+    public function testHasAccessParenthesesDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('(admin && write) || superadmin'));
+    }
+
+    public function testHasAccessNestedGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('read && (write || admin)'));
+    }
+
+    public function testHasAccessNestedDenied(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertFalse($user->hasAccess('admin && (write || read)'));
+    }
+
+    public function testHasAccessComplexGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess('(read || admin) && (write || superadmin)'));
+    }
+
+    public function testHasAccessEmptyExpressionGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess(''));
+    }
+
+    public function testHasAccessNullExpressionGranted(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->assertTrue($user->hasAccess(null));
+    }
+
+    /**
+     * Administrator short-circuit: an admin with **zero** permissions still
+     * gets `true` for any expression, including ones referencing permissions
+     * the admin does not hold.
+     */
+    public function testHasAccessAdministratorShortCircuit(): void
+    {
+        $user = $this->buildUser(true, []);
+
+        $this->assertTrue($user->hasAccess('admin && write'));
+    }
+
+    public function testHasAccessInvalidExpressionThrows(): void
+    {
+        $user = $this->buildUser(false, ['read' => true, 'write' => true]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $user->hasAccess('&&& invalid');
+    }
+}

--- a/migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_Foundation-Consolidation-Closure.md
+++ b/migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_Foundation-Consolidation-Closure.md
@@ -1,0 +1,399 @@
+# Step 2.0: Foundation Consolidation — Parent-Step Closure & Gap Audit
+
+**ROADMAP:** 2.0 — Foundation Consolidation (parent step closure).
+**GitHub Issue:** #181.
+**Prerequisite:** Steps **2.0.0 → 2.0.8** all merged (✅) on `develop`.
+**Priority:** HIGH — gates the start of Roadmap Step 2.1 (Static Analysis & Code Quality).
+
+**Closes Phase 1 audit:** none directly. This step verifies that the Phase 1 audit closures already claimed by 2.0.0–2.0.8 are accurate (cross-check) and identifies any remaining cross-cutting Foundation-Consolidation debt that warrants new sub-steps before Phase 2.1 starts.
+
+**Also read:**
+- `.cursor/ROADMAP.md` (5 aggressive rules + tracking table)
+- `migration-docs/TODO/PHASE_2_MODERNISING.md` (Step 2.0 + sub-step sections)
+- `migration-docs/audits/2026/03/AUDIT_REPORT_STEP_2.0-2.0.2_2026-03-27.md` (prior partial audit — **only covered 2.0–2.0.2**, NOT 2.0.3–2.0.8)
+- `migration-docs/audits/2026/02/phase1/AUDIT_REPORT_2026-02-06.md` (Phase 1 audit findings — source of truth for the "Closes Phase 1 audit:" claims in each sub-step)
+
+---
+
+## 0. NATURE OF THIS STEP — READ FIRST
+
+**This is NOT a feature step.** Step 2.0 in the ROADMAP is a *parent / umbrella step*; the actual modernization work lives in 2.0.0–2.0.8 (already merged). This task is the **closure-and-gap audit** for that umbrella:
+
+1. **Verify** every claim made by 2.0.0–2.0.8 about scope, deletions, audit closures, and "no-mercy" compliance is still true on `develop`.
+2. **Detect** any Foundation-Consolidation work that was promised, deferred, missed, or surfaced *during* 2.0.x execution but never landed and never got its own ticket.
+3. **Decide** per gap whether it belongs in:
+   - a **new Step 2.0.X sub-step** (where X = next free integer ≥ 9), OR
+   - a different existing step (2.1.x / 2.2 / 2.5 / etc.) — in which case cross-link, do NOT duplicate, OR
+   - is genuinely complete and the audit just records it.
+4. **Update** `.cursor/ROADMAP.md` and `migration-docs/TODO/PHASE_2_MODERNISING.md` accordingly.
+5. **Open** GitHub issues for every new sub-step (one issue per new sub-step) using the `.cursor/skills/github-issue-creator/SKILL.md` skill.
+6. **Write** an audit report in `migration-docs/audits/2026/{MM}/AUDIT_REPORT_STEP_2.0_FOUNDATION_CLOSURE_{YYYY-MM-DD}.md`.
+7. **Close** Step 2.0 in the ROADMAP if and only if **no `must-fix-before-2.1`** gaps remain (deferred work → new sub-steps; closure may still happen). If gaps are blocking, leave 2.0 ⏳ until those new sub-steps land — but the audit report itself, the new sub-step ROADMAP rows, the new PHASE_2 sections, and the new agent-prompt skeletons are still produced **in this PR**.
+
+> Code refactors are **out of scope**. Code-level fixes for any newly identified gaps belong in their *own* new sub-steps (2.0.9 / 2.0.10 / …), not in this PR.
+> The only code touched in this PR is what `php pagekit setup` / cache regenerates and the audit machinery (markdown + agent-prompt skeletons + ROADMAP + PHASE_2 doc). No PHP source files, no JS, no LESS.
+
+---
+
+## 1. CONTEXT
+
+### 1.1 Why this step exists
+
+Step 2.0 has eight merged sub-steps (2.0.0 through 2.0.8). Each one self-reported its own "Closes Phase 1 audit: …" claims and "No-Mercy compliance" matrix. Before opening Step 2.1 (PHPStan / strict_types / CI/CD), we need a **single, holistic audit** that:
+
+- Cross-checks each sub-step's scope on the actual `develop` HEAD (no trust in PR descriptions).
+- Confirms that the Phase 1 audit cells flipped to 🛡️ (and the ones still ⚠️ — like 1.11) reflect ground truth.
+- Surfaces "Out of scope" / "Deferred" items that were tagged inside sub-step prompts (`Step 2.X.Y (Name)`, `TEMPORARY BRIDGE`, `AUDIT FIX`, `BACKWARD COMPATIBILITY`) but never got a ticket.
+- Catches drift between PHASE_2_MODERNISING.md and the actual code.
+- Leaves the foundation in a known-clean state so 2.1.x can land cleanly on top.
+
+The earlier audit report (`AUDIT_REPORT_STEP_2.0-2.0.2_2026-03-27.md`) only covers **2.0 → 2.0.2**. Six sub-steps (2.0.3 → 2.0.8) have no consolidated audit yet.
+
+### 1.2 Goal
+
+A short, evidence-based audit report plus zero-or-more new ROADMAP rows / PHASE_2 sections / `PROMPT_2_0_X_*.md` skeletons capturing every Foundation-Consolidation gap, so that Step 2.0 can be marked ✅ / 🛡️ in the ROADMAP without leaving silent debt behind.
+
+### 1.3 Scope (what counts as "Foundation Consolidation")
+
+Foundation Consolidation = applying the 5 Aggressive Rules **retroactively** to Phase 1 deliverables. In particular:
+
+- **Rule 1** No compatibility layers. — search for `Bridge`, `Adapter`, `Compat`, `Shim`, `Legacy`, `Wrapper`.
+- **Rule 2** No adapters. — same as above + facades and trait wrappers added to "smooth migration".
+- **Rule 3** Breaking changes allowed internally. — confirm no sub-step kept old + new in parallel "for safety".
+- **Rule 4** Delete over wrap. — search for commented-out legacy blocks, `@deprecated`, `*.legacy.php`, `class_alias` migration shims.
+- **Rule 5** Mandatory flagging & audit debt. — every remaining TODO using ROADMAP IDs (`Step X.Y`, `TEMPORARY BRIDGE`, `AUDIT FIX`, `BACKWARD COMPATIBILITY`, `Must be refactored later`) must point at an *existing* (or newly-created-by-this-step) ROADMAP entry.
+
+Anything that is **NOT** Foundation Consolidation belongs to other phases and is out of scope for *new* sub-steps under 2.0.X:
+
+- Static analysis / typing → **2.1.x**
+- CI/CD pipelines → **2.2**
+- Docker prod → **2.3**
+- Build tools (Webpack/Vite/Vue3) → **2.4 / 3.x**
+- Extension safety / sandbox → **2.5**
+- Security hardening / API v2 → **4.x**
+
+If the audit finds typing / null-safety / `mixed` debt, route it to the existing 2.1.x rows (and add it under "Audit findings (Phase 1 review)" inside that step's PHASE_2 section), do NOT mint a new 2.0.X sub-step.
+
+---
+
+## 2. SAFETY & VERIFICATION
+
+**Workspace root.** Standard commands:
+
+```bash
+./app/vendor/bin/phpunit
+./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M
+php pagekit list
+php pagekit setup
+```
+
+All four MUST stay green throughout this audit. If any baseline command is red on a fresh clone of `develop`, **stop and escalate** — that is itself a 2.0 closure blocker and must be resolved (likely as a new sub-step) before Step 2.0 closes.
+
+---
+
+## 3. AUDIT METHODOLOGY (per sub-step)
+
+For each merged sub-step **2.0.0 → 2.0.8**, the audit subagent (via the Architect's checklist) must produce a short evidence block in the audit report covering exactly the items in §3.1–§3.6.
+
+### 3.1 Scope verification
+
+- Read the sub-step's row in `.cursor/ROADMAP.md`, its section in `PHASE_2_MODERNISING.md`, its agent prompt under `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/`, and its branch doc under `migration-docs/branches/`.
+- Cross-check the *claimed* deletions / modifications against `develop` HEAD with ripgrep.
+
+### 3.2 Phase 1 audit closure verification
+
+For every `Closes Phase 1 audit: Step 1.X` claim:
+- Look up the corresponding row in `.cursor/ROADMAP.md` — is the Audit column actually `🛡️`?
+- Look up the original 1.X audit findings in `migration-docs/audits/2026/02/phase1/AUDIT_REPORT_2026-02-06.md` — are *all* findings closed, or only some? Partial closures must be flagged.
+- 1.11 (ORM Modernization) is currently **partial** (2.0.8 closed the User-model portion; 2.1.6 still pending). Confirm this is reflected as ⚠️ in the ROADMAP and explicitly noted in the audit report.
+
+### 3.3 No-Mercy compliance spot-check
+
+Run these searches across the live codebase (excluding `app/vendor/`):
+
+```bash
+rg -n "Bridge|Adapter|Compat|Shim|Legacy|Wrapper" app/ packages/ --glob "*.php" \
+  --glob "!*Test.php"
+rg -n "@deprecated" app/ packages/ --glob "*.php"
+rg -n "class_alias" app/ packages/ --glob "*.php"
+rg -n "TEMPORARY BRIDGE|AUDIT FIX|BACKWARD COMPATIBILITY|Must be refactored later" \
+  app/ packages/ --glob "*.php" --glob "*.js" --glob "*.vue" --glob "*.less"
+```
+
+For every hit, classify:
+- **OK / by design** (e.g. Pagekit's own `EventDispatcher`, `PrefixEventDispatcher`, `RouterAdapter` if it's a stable platform API — not a compat layer).
+- **OK / tagged with valid future ROADMAP ID** (e.g. `// TODO: Must be refactored in Step 2.1.6`).
+- **GAP** — needs a new sub-step or routing into an existing future step.
+
+### 3.4 Deferred-item audit (per sub-step "Out of scope" sections)
+
+Each sub-step prompt has an "Out of scope" / "Deferred" section. For example:
+- **2.0.7** deferred `GetResponseEvent` rename → tagged `2.1.x`. Verify the rename is actually planned somewhere (currently only mentioned in 2.1.6 PHASE_2 prose). If not, flag it.
+- **2.0.8** deferred extracting `evaluateBooleanExpression()` into `PermissionExpressionEvaluator` → tagged `2.5 (Extension Safety System)`. Confirm 2.5's section mentions this or accept the deferral as informational only.
+- **2.0.4** PHASE_2 audit-findings list — any unchecked items?
+- **2.0.6** PHASE_2 audit-findings list — any unchecked items?
+
+For each "deferred item" found:
+- If it has a clear future home (existing 2.1.x / 2.5 / etc.) → add it to that step's PHASE_2 "Audit findings (Phase 1 review)" / "Audit findings (Step 2.0.X review)" subsection (one of those headers must exist).
+- If it has *no* clear future home → mint a new 2.0.X sub-step.
+
+### 3.5 Cross-cutting Foundation-Consolidation gap search
+
+Items the per-sub-step audit will not catch:
+
+- **`@deprecated` markers across modules** — Rule 4 says "delete, don't deprecate". Each one is a potential gap.
+- **Compatibility wrappers around modern APIs** that survived 2.0.1 (PSR-11), 2.0.3 (PSR-6 cache), 2.0.4 (Migrations), 2.0.7 (Event dispatcher).
+- **Module-level config drift**: e.g. `phpunit.xml.dist` per module (resolved in 2.0.6 — verify), `composer.json` autoload entries per module (resolved in 2.0.5 — verify).
+- **Doctrine ORM legacy patterns** still alive in `app/system/modules/orm/` and `app/modules/database/`: `EntityManager` singleton, `ModelServiceLocator` static service locator, `IntlServiceLocator` static service locator. These are **routed to 2.1.6**; confirm they appear in 2.1.6's PHASE_2 section under "Audit findings (Phase 1 review)" and not lost.
+- **Validator / translator integration (2.0.2)**: any remaining manual-validation controllers? `MenuApiController` was flagged as 2.1.9 carryover — confirm.
+- **Cache (2.0.3)**: any `CacheInterface` / `Psr6Adapter` references remain? Should be zero.
+- **Migrations (2.0.4)**: `DatabaseHandler::createTable()` removed? `Version001_*` blog migration renamed to timestamp format? `MigrationServiceTest` un-skipped?
+- **Event dispatcher (2.0.7)**: zero `SymfonyEventDispatcherBridge` / `symfony.event_dispatcher` references on `develop`? PHPStan baseline clean?
+- **`User::hasAccess()` (2.0.8)**: zero `create_function` references in `app/` / `packages/`? PHPStan baseline entry for `function.notFound` removed?
+- **Frontend (Vue 2 / UIkit)**: any `// TODO: Refactor in Phase 3 (Vue Migration)` markers added during 2.0.x that are now stale because the code path was deleted? Stale markers count as Rule-5 violations (debt without owner).
+
+### 3.6 Documentation drift
+
+- **`.cursor/ROADMAP.md`**: every 2.0.x row has Status = ✅, Audit ∈ {🛡️, ⚠️ (only 1.11-cross-cut is allowed at this layer)}, PR linked.
+- **`PHASE_2_MODERNISING.md`**: every 2.0.x section has its "Closes Phase 1 audit:" line, its Agent Prompt path, and (if applicable) its "Audit findings" subsection.
+- **`migration-docs/branches/`**: a branch doc exists per sub-step (file naming convention: `step-2-0-X-*.md` or `*_MIGRATION.md` for older sub-steps). Missing branch docs are a documentation-debt gap.
+- **`README.md`**: any references to features / commands / file paths that 2.0.x changed and that README still describes the old way? (E.g. cache, migrations, event dispatcher.)
+- **`AGENTS.md`**: same check — any pitfalls or service mappings that 2.0.x invalidated?
+- **`CHANGELOG-NEW.md`**: every 2.0.x entry has a coherent section, no missing versions in the chain `1.2.5 → 1.2.13`.
+
+---
+
+## 4. AUDIT OUTPUT FORMAT
+
+The audit subagent produces ONE markdown file at:
+
+```
+migration-docs/audits/2026/{MM}/AUDIT_REPORT_STEP_2.0_FOUNDATION_CLOSURE_{YYYY-MM-DD}.md
+```
+
+Where `{YYYY-MM-DD}` is the audit date (today) and `{MM}` is the two-digit month. Use the format of `migration-docs/audits/2026/03/AUDIT_REPORT_STEP_2.0-2.0.2_2026-03-27.md` as a reference (Executive Summary → Scope table → Detailed Findings Per Step → Cross-Cutting Verification → Dependency Chain → PR Timeline → Recommendations → Final Test Summary → Conclusion).
+
+Mandatory sections:
+
+1. **Executive Summary** — one paragraph, plus a "Closure Verdict" table:
+
+   | ID    | Sub-step                              | Audit ground-truth | New sub-step needed? |
+   |-------|---------------------------------------|--------------------|----------------------|
+   | 2.0.0 | Controller Attributes                 | 🛡️ / ⚠️ / ❌       | none / 2.0.X / 2.1.x |
+   | 2.0.1 | PSR-11 Container Modernization        | …                  | …                    |
+   | …     | …                                     | …                  | …                    |
+   | 2.0.8 | User::hasAccess() Hotfix              | …                  | …                    |
+
+2. **Per-sub-step evidence blocks** (2.0.0 → 2.0.8) — each ≤ 20 lines:
+   - Scope verified (✅ / ❌ + ripgrep evidence)
+   - Phase 1 closure claims verified (✅ / ⚠️ partial / ❌)
+   - No-Mercy spot-check (✅ / list of suspect hits)
+   - Deferred items still tracked (✅ / list of orphaned items)
+
+3. **Cross-Cutting Verification** — global ripgrep tables (one row per pattern, plus classification).
+
+4. **Gap List** — one row per gap, with the proposed disposition:
+
+   | # | Gap (one line)                           | Disposition                | Target               |
+   |---|------------------------------------------|----------------------------|----------------------|
+   | 1 | E.g. `DatabaseHandler::createTable()` still present | new sub-step             | **2.0.9 (DDL Hardening)** |
+   | 2 | E.g. `MenuApiController` manual validation | route to existing step    | 2.1.9 (already listed) |
+   | 3 | …                                        | …                          | …                    |
+
+5. **New Sub-Step Proposals** — full skeleton for each new 2.0.X (see §5).
+
+6. **PHASE_2 / ROADMAP / Issue Updates** — exact diffs proposed (in this PR).
+
+7. **Closure Verdict** — one of:
+   - ✅ Step 2.0 can be closed (`✅` Status + `🛡️` Audit) in this PR. New sub-steps (if any) are non-blocking and may land later.
+   - ⚠️ Step 2.0 stays `⏳` until new sub-steps 2.0.9 / 2.0.10 / … land. Document the dependency in `PHASE_2_MODERNISING.md`.
+
+---
+
+## 5. NEW SUB-STEP CREATION PROCEDURE
+
+For every gap that warrants a new sub-step, the Architect produces (in this PR):
+
+### 5.1 Numbering rule
+
+Next free integer ≥ 9. So the first new sub-step is **2.0.9**, next **2.0.10**, etc. Never reuse a number; never re-letter (no `2.0.8a`).
+
+### 5.2 ROADMAP row
+
+Insert immediately after the last existing 2.0.X row (currently 2.0.8) in `.cursor/ROADMAP.md`:
+
+```markdown
+| 2.0.9  | ↳ {Concise Task Name}                 | ⏳     | ⏳    | #{ISSUE} | -       |
+```
+
+The Audit column is `⏳` (not `⚠️`) because the work has not started yet.
+
+### 5.3 PHASE_2 section
+
+Insert in `migration-docs/TODO/PHASE_2_MODERNISING.md` immediately after the existing **Step 2.0.8** subsection, before the **Step 2.1** header. Required fields (verbatim labels):
+
+```markdown
+### Step 2.0.9: {Concise Task Name}
+
+- **Goal**: {one sentence}
+- **Prerequisite**: Step 2.0.8 (or whichever earlier step is the real prerequisite — usually 2.0.{N-1})
+- **Priority**: {LOW / MEDIUM / HIGH}
+- **Context**: {why this is foundation-consolidation; why it was missed by the original 2.0.X plan; reference the 2026-04 closure audit}
+- **Closes Phase 1 audit**: {Step 1.X (Name) ⚠️ → 🛡️} — or `none` if the gap is purely a 2.0.x leftover.
+- **Tasks**:
+  - {bulleted, atomic, 5–15 items}
+- **Result**: {one sentence}
+- **Risk**: {Low / Medium / High}
+- **Affected Files**: {ripgrep-derived list}
+- **Agent Prompt**: `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_9_{Slug}.md`
+
+---
+```
+
+### 5.4 Agent prompt skeleton
+
+Create `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_9_{Slug}.md` (and analogously for 2.0.10, 2.0.11, …) using the structure of an existing prompt — `PROMPT_2_0_7_Event-Bridge-Removal.md` or `PROMPT_2_0_8_User-hasAccess-Hotfix.md` are good templates.
+
+Mandatory sections in each new prompt:
+1. Title (`# Step 2.0.X: {Name}`)
+2. ROADMAP / GitHub Issue / Prerequisite / Priority header block
+3. `Closes Phase 1 audit:` line (or "none" with rationale)
+4. `Also read:` line (`.cursor/ROADMAP.md`, relevant PHASE_2 section)
+5. **§1 CONTEXT** — bug / debt description, current code excerpt, why this is needed
+6. **§2 SAFETY & VERIFICATION** — standard test commands
+7. **§3 IMPLEMENTATION** — concrete steps, file paths, before/after diffs where applicable
+8. **§4 TESTS** — new + existing tests that must pass
+9. **§5 SUCCESS CRITERIA** — actionable, ripgrep-verifiable bullet list
+10. **§6 OUT OF SCOPE** — what NOT to touch; defer to which step
+11. `**End of prompt.**`
+
+Skeletons may leave `§3` and `§4` thin (≤ 10 bullets) — the Architect for that future step will flesh them out. The skeleton must be detailed enough that a downstream Architect can produce a usable ticket plan from it.
+
+### 5.5 GitHub issue
+
+Use the `.cursor/skills/github-issue-creator/SKILL.md` skill to open one issue per new sub-step on `Shadesman5/pagekit`. Required fields:
+
+- **Title**: `Step 2.0.X: {Concise Task Name}`
+- **Labels**: `phase-2`, plus `migration` *and / or* the relevant area label (`backend`, `database`, `module`, `theme`, `frontend`, `migration` per `.cursor/rules/github-labels.mdc`)
+- **Milestone**: `Phase 2: Developer Experience`
+- **Body**: short markdown summary linking to the new PHASE_2 section + new agent prompt path; reference the 2.0 closure audit report; mention the parent issue (#181)
+- **Parent issue**: link to **#181** as parent (sub-issue relationship)
+
+After issue creation, write the issue number into the new ROADMAP row and into the new PHASE_2 section's `Agent Prompt` line preamble (replace placeholder `#{ISSUE}`).
+
+### 5.6 No code in this PR
+
+The new sub-steps are **paper only** in this PR (ROADMAP row + PHASE_2 section + prompt skeleton + GitHub issue). Their actual implementation happens in their own future PRs. This keeps the closure PR small and reviewable.
+
+---
+
+## 6. EXISTING-STEP UPDATES (when a gap routes elsewhere)
+
+If a gap belongs to an existing future step (most likely 2.1.6 or 2.1.9), update *that step's* PHASE_2 subsection only:
+
+1. Append the gap to that step's `**Audit findings (Phase 1 review):**` (or create the subsection if missing) under `migration-docs/TODO/PHASE_2_MODERNISING.md`.
+2. Add a one-liner pointer in the audit report's "Gap List" table referencing the change.
+3. Do **NOT** create a new agent prompt — the existing step's prompt covers it.
+4. Do **NOT** open a new GitHub issue — the existing step's issue covers it; if needed, add a comment on that issue referencing the closure audit.
+
+---
+
+## 7. ROADMAP TABLE FINAL STATE (post-this-PR)
+
+After this step lands, the ROADMAP tracking table for Step 2.0 must look approximately like:
+
+```markdown
+| 2.0    | **Foundation Consolidation**          | ✅ or ⏳ | 🛡️ or ⏳ | #181  | #{THIS_PR} |
+| 2.0.0  | ↳ Controller Attributes               | ✅      | 🛡️      | #142  | #111       |
+| 2.0.1  | ↳ PSR-11 Container Modernization      | ✅      | 🛡️      | #145  | #174       |
+| 2.0.1a–e | ↳ (sub-stages, unchanged)           | ✅      | 🛡️      | …     | …          |
+| 2.0.2  | ↳ Validator-Translator Integration    | ✅      | 🛡️      | #146  | #175       |
+| 2.0.3  | ↳ Cache API Full Modernization        | ✅      | 🛡️      | #179  | #187       |
+| 2.0.4  | ↳ Package/Migration System Redesign   | ✅      | 🛡️      | #180  | #189       |
+| 2.0.5  | ↳ Composer & Autoload Hygiene         | ✅      | 🛡️      | #182  | #192       |
+| 2.0.6  | ↳ Test Infrastructure Cleanup         | ✅      | 🛡️      | #183  | #193       |
+| 2.0.7  | ↳ Event Dispatcher Bridge Removal     | ✅      | 🛡️      | #184  | #195       |
+| 2.0.8  | ↳ Hotfix: `create_function()` in User | ✅      | 🛡️      | #185  | #197       |
+| 2.0.9  | ↳ {New sub-step from gap audit}       | ⏳      | ⏳      | #?    | -          |
+| 2.0.10 | ↳ {Next new sub-step, if any}         | ⏳      | ⏳      | #?    | -          |
+| …      | …                                     | …       | …       | …     | …          |
+```
+
+Closure rules:
+- If **zero** new sub-steps: 2.0 row → `✅` / `🛡️`.
+- If **one or more** new sub-steps and any of them is **must-fix-before-2.1**: 2.0 row stays `⏳` / `⏳`, and the new sub-steps are listed as prerequisites for Step 2.1 in the relevant PHASE_2 entries.
+- If **one or more** new sub-steps but all are non-blocking: 2.0 row → `✅` / `🛡️`, and the new sub-steps land later in their own PRs.
+
+The "must-fix-before-2.1" decision is the Architect's call, documented in the audit report's Conclusion.
+
+---
+
+## 8. DEFINITION OF DONE (for this PR)
+
+- [ ] Audit report exists at `migration-docs/audits/2026/{MM}/AUDIT_REPORT_STEP_2.0_FOUNDATION_CLOSURE_{YYYY-MM-DD}.md` and follows the §4 format.
+- [ ] Per-sub-step evidence blocks for **all** of 2.0.0, 2.0.1 (incl. 2.0.1a–e), 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8.
+- [ ] Cross-cutting ripgrep tables present and classified.
+- [ ] Gap List present (may be empty if zero gaps, but the section header must exist with the explicit phrase "no gaps detected").
+- [ ] For every "new sub-step" gap:
+  - [ ] ROADMAP row inserted with correct Issue number.
+  - [ ] PHASE_2 section inserted with all mandatory fields.
+  - [ ] Agent-prompt skeleton file exists at `agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_X_*.md`.
+  - [ ] GitHub issue opened with parent-issue link to #181.
+- [ ] For every "route to existing step" gap: target step's PHASE_2 section updated.
+- [ ] If closure verdict is ✅ on 2.0:
+  - [ ] ROADMAP row 2.0 updated to `✅` / `🛡️` with this PR linked.
+  - [ ] ROADMAP header `Current Step` advanced to `2.1.2` (since 2.1.1 is already done).
+  - [ ] If closure verdict is ⚠️: ROADMAP row 2.0 stays `⏳` / `⏳` and Current Step pointer advances to the **first new sub-step** (e.g. `2.0.9`).
+- [ ] `./app/vendor/bin/phpunit` green.
+- [ ] `./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M` green.
+- [ ] `php pagekit list` green.
+- [ ] `php pagekit setup` green.
+- [ ] CHANGELOG-NEW.md has a `## Pagekit X.Y.Z - Foundation Consolidation Closure ({DATE})` section.
+- [ ] Branch doc at `migration-docs/branches/step-2-0-foundation-closure.md` exists, summarising the audit verdict and any new sub-steps.
+- [ ] Version bumped via `.cursor/skills/version-bump/SKILL.md` (third-digit patch — this PR is `docs`/`chore` heavy).
+
+---
+
+## 9. ORCHESTRATOR / ARCHITECT GUIDANCE (Roadmap Step → Checklist)
+
+This task is unusually **discovery-heavy**. The Architect's checklist should reflect that. Suggested structure (the Architect MAY adjust):
+
+1. Pre-flight baseline (PHPUnit / PHPStan / `pagekit list` / `pagekit setup` all green on `develop`).
+2. Sub-step audit loop — one Checklist Step per audited sub-step (eight steps total: 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8). Each produces an evidence block in the audit report.
+3. Cross-cutting ripgrep sweep — one Checklist Step.
+4. Gap list assembly + disposition decisions — one Checklist Step.
+5. For each new sub-step (zero or more): one Checklist Step that creates ROADMAP row + PHASE_2 section + prompt skeleton + GitHub issue.
+6. For each "route to existing step" gap: one Checklist Step updating the target PHASE_2 subsection.
+7. Audit-report finalisation (Executive Summary + Conclusion + Closure Verdict).
+8. Branch doc + CHANGELOG-NEW + version bump + ROADMAP closure (or non-closure) update — one Checklist Step each.
+9. Final test gate (PHPUnit + PHPStan + `pagekit setup` + `pagekit list` + Playwright E2E `installation` + `authentication` + `dashboard`).
+
+Per-step gate is **PHPUnit + PHPStan** as usual. Final gate adds `pagekit setup` + `pagekit list` + Playwright (chromium-only per `AGENTS.md`).
+
+The Refactorer MUST NOT touch PHP / JS / LESS source files in this PR. If the audit report concludes that a code fix is genuinely "must-fix-now" (e.g. another fatal-on-PHP-8 bug like 2.0.8 was), abort this closure PR and open a hotfix sub-step PR first; this audit can then resume.
+
+---
+
+## 10. NON-GOALS (out of scope for this step)
+
+- ❌ Running PHPStan at level 6/7/8 — that is 2.1.4 / 2.1.5 / 2.1.6.
+- ❌ Adding `declare(strict_types=1)` anywhere — that is 2.1.3.
+- ❌ Refactoring `EntityManager` singleton, `ModelServiceLocator`, `IntlServiceLocator` — those are 2.1.6.
+- ❌ Implementing CI/CD workflows — that is 2.1.2 / 2.2.
+- ❌ Vue 2 / UIkit / frontend modernization — that is Phase 3.
+- ❌ Re-running 2.0.x sub-steps — they are merged. If a sub-step delivered something incorrect, the fix is a *new* sub-step, not an amend.
+
+---
+
+## 11. SUCCESS CRITERIA SUMMARY
+
+- [ ] Single, evidence-based audit report covering all 2.0.x sub-steps.
+- [ ] All Foundation-Consolidation gaps either closed (Phase 1 audit cells correct), routed (existing future-step PHASE_2 section updated), or scheduled (new 2.0.X sub-step created with ROADMAP + PHASE_2 + prompt + issue).
+- [ ] ROADMAP table in a deterministic, post-2.0 state per §7.
+- [ ] No code in `app/`, `packages/`, or frontend assets touched by this PR (audit machinery and docs only).
+- [ ] All test gates green.
+- [ ] `Closes #181` in PR body and `<!-- metadata -->` block.
+
+---
+
+**End of prompt.**

--- a/migration-docs/branches/step-2-0-8-user-hasaccess-hotfix.md
+++ b/migration-docs/branches/step-2-0-8-user-hasaccess-hotfix.md
@@ -1,0 +1,236 @@
+# Step 2.0.8 — User::hasAccess() Hotfix (`create_function()` Removal)
+
+**Branch:** `cursor/step-2-0-8-user-hasaccess-hotfix-60e0`
+**ROADMAP Step:** 2.0.8 (Foundation Consolidation — User::hasAccess() Hotfix)
+**GitHub Issue:** [#185](https://github.com/Shadesman5/pagekit/issues/185)
+**Status:** ✅ Complete — Ready for Review
+**Date:** 2026-04-27
+
+---
+
+## 🎯 Overview
+
+Step 2.0.8 fixes a latent **fatal-on-PHP-8** bug inside the core authorization
+helper `Pagekit\User\Model\User::hasAccess()`. The legacy implementation
+delegated boolean expression evaluation to PHP's `create_function()`:
+
+```php
+// BEFORE (fatal on PHP 8.x)
+if (!$fn = @create_function('', "return ({$exp});")) {
+    throw new \InvalidArgumentException(sprintf(
+        'Unable to parse the given access string "%s"', $expression
+    ));
+}
+return (bool) $fn();
+```
+
+`create_function()` was deprecated in PHP 7.2 and **removed in PHP 8.0**.
+Pagekit declares `"php": "^8.2"` in `composer.json`, so on every non-trivial
+permission check (anything containing `&`, `|`, `(`, `)` or `!`) the call site
+would have produced a fatal `Call to undefined function create_function()`.
+The simple-permission and administrator short-circuits masked the regression in
+trivial paths, but the moment any composite expression hit the fall-through —
+e.g. `read && write`, `(admin || editor) && publish` — the entire
+authorization stack would have crashed.
+
+This step replaces the `create_function()`-based evaluator with a
+**pure-PHP recursive-descent parser** living as a `private static` method on
+the same class, with **no `eval()`**, no `Closure::fromCallable`, no
+`assert()`, and no Symfony `ExpressionLanguage` dependency. Per the
+No-Mercy / Aggressive Modernization rules (`.cursor/ROADMAP.md`):
+
+- **Rule 1 (No Compatibility Layers):** no shim, no PHP-version branch.
+- **Rule 2 (No Adapters):** no separate `PermissionExpressionEvaluator`
+  service / class — the helper is `private static` on `User` because it has
+  exactly one caller (Rule 1 + Rule 2 together).
+- **Rule 4 (Delete Over Wrap):** the `if (!$fn = @create_function(...))` and
+  `return (bool) $fn();` lines are physically deleted, not commented out, not
+  toggled by a feature flag.
+
+A **new dedicated test file** locks the behaviour in place: 37 unit tests, 765
+suite assertions total, covering both the bare evaluator (via
+`\ReflectionMethod` since the helper is `private static`) and `hasAccess()`
+end-to-end via partial PHPUnit mocks.
+
+---
+
+## ✅ What Changed
+
+### ✏️ Edited
+
+- `app/system/modules/user/src/Model/User.php`
+  - Replaced the `create_function()` block in `hasAccess()` with
+    `try { return self::evaluateBooleanExpression($exp); } catch (\Throwable) { … }`
+    that throws a clean `\InvalidArgumentException` with the original
+    user-facing message (`Unable to parse the given access string "%s"`).
+  - Added `private static function evaluateBooleanExpression(string $exp): bool`
+    — a recursive-descent parser implementing the grammar:
+    ```
+    expr     → orExpr
+    orExpr   → andExpr ( ('||' | '|') andExpr )*
+    andExpr  → notExpr ( ('&&' | '&') notExpr )*
+    notExpr  → '!' notExpr | atom
+    atom     → '(' expr ')' | '0' | '1'
+    ```
+    with operator precedence `!` > `&&` > `||`. Both **single** (`&`, `|`)
+    and **double** (`&&`, `||`) operators are accepted because the upstream
+    sanitization regex in `hasAccess()` preserves single operators.
+  - Preserved unchanged: the `isAdministrator() || empty($expression)`
+    early-exit, the `!preg_match('/[&\(\)\|\!]/', $expression)` simple-permission
+    short-circuit, and the regex reduction that produces the
+    `0/1/&/|/!/()` string `$exp`.
+- `phpstan-baseline.neon`
+  - Removed the now-stale `Function create_function not found.` ignore entry
+    scoped to `app/system/modules/user/src/Model/User.php` (6 lines). The
+    suppression is part of the deletion (Rule 4).
+
+### ➕ Added
+
+- `app/system/modules/user/src/Tests/UserAccessTest.php` — **new file**
+  (37 test cases, pure unit tests, no DB, no container, no kernel bootstrap;
+  uses `getMockBuilder(User::class)->onlyMethods(['isAdministrator', 'hasPermission'])`
+  for `hasAccess()` integration cases and `\ReflectionMethod` for the bare
+  evaluator).
+
+### ➖ Net diff
+
+- `app/system/modules/user/src/Model/User.php` — `+96 / −9`
+- `phpstan-baseline.neon` — `+0 / −6`
+- `app/system/modules/user/src/Tests/UserAccessTest.php` — `+294` (new file)
+- **3** paths touched, **0** shims, **0** adapters, **0** `@deprecated` markers,
+  **0** new in-code TODOs.
+
+---
+
+## 🧱 Commits (Conventional Commits)
+
+| SHA        | Subject                                                                  | Checklist Steps |
+|------------|--------------------------------------------------------------------------|-----------------|
+| `f99ac338` | `fix(user): replace create_function with safe boolean evaluator`         | #2 + #3 + #4    |
+| `890c1c97` | `test(user): add UserAccessTest for boolean evaluator and hasAccess`     | #5              |
+
+Each commit references `ROADMAP Step 2.0.8, Issue #185` in its body for
+ROADMAP traceability. Steps #1 and #6 are pure verification gates and produced
+no code changes (per the architect's plan).
+
+---
+
+## 🛡️ No-Mercy Compliance
+
+| Rule                                              | Outcome |
+|---------------------------------------------------|---------|
+| **Rule 1 — No Compatibility Layers**              | ✅ No `eval()`, no `Closure::fromCallable`, no `assert()`, no `ExpressionLanguage`, no PHP-version branch |
+| **Rule 2 — No Adapters**                          | ✅ No `PermissionExpressionEvaluator` class, no helper trait, no facade — single `private static` method on `User` |
+| **Rule 3 — Breaking Changes Allowed Internally**  | ✅ The fatal-on-PHP-8 path is fixed; the public API surface (`User::hasAccess()` signature + behaviour for valid expressions) is identical |
+| **Rule 4 — Delete Over Wrap**                     | ✅ `create_function()` block physically deleted; PHPStan baseline entry pruned alongside |
+| **Rule 5 — Mandatory Flagging**                   | ✅ No new in-code TODOs needed; deferrals are documented in this branch doc + the architect plan |
+| **PHP 8.2+ hygiene**                              | ✅ `declare(strict_types=1)` already present, new method has typed parameters and return type, `\Throwable` catch uses PHP 8 capture-less syntax |
+| **No WP/Laravel artifacts**                       | ✅ |
+| **Diff scope**                                    | ✅ Exactly the three paths from the architect's plan |
+
+---
+
+## 🧪 Test Results
+
+### Static analysis
+- ✅ `./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M` — `[OK] No errors` (baseline clean)
+
+### PHPUnit
+- ✅ `./app/vendor/bin/phpunit` — **326 tests, 765 assertions, 0 failures, 0 errors**
+  - `UserAccessTest` discovered via the existing `app/system/modules/*/src/Tests` glob
+  - Test count delta: 289 → 326 (+37)
+  - Exit code 1 is solely due to **pre-existing** SMTP/network-dependent
+    warnings + deprecations (unrelated to this step)
+
+### Console
+- ✅ `php pagekit setup` — clean (fresh DB / config bootstrap)
+- ✅ `php pagekit list` — Pagekit 1.2.13, all commands listed
+
+### Playwright (chromium only, per `AGENTS.md`)
+- ✅ `tests/e2e/specs/01-setup/installation.spec.js` — 1 passed
+- ✅ `tests/e2e/specs/02-core/authentication.spec.js` — 14 passed
+  *(login flow exercises the authorization stack — the closest production-shaped smoke test for `hasAccess()`)*
+- ✅ `tests/e2e/specs/02-core/dashboard.spec.js` — 10 passed
+
+### Final ripgrep audit (live codebase only)
+- ✅ `rg "create_function" app/ packages/ --glob "*.php"` → **0 functional hits**
+  (one docblock mention in `User.php` at line 236 documents what the helper *replaces*; not live code)
+- ✅ `rg "create_function" app/vendor --glob "*.php"` → **0 hits** (informational)
+- ✅ `rg "eval\s*\(" app/system/modules/user/src/Model/User.php` → **0 functional hits**
+  (one docblock mention only)
+
+---
+
+## 🧨 Behavioural Contract
+
+### Inputs to the new evaluator (after the upstream regex reduction in `hasAccess()`)
+
+The upstream regex maps every permission name to `0` or `1` based on
+`hasPermission()`, then keeps only `0`, `1`, `&`, `|`, `!`, `(`, `)`. Whitespace
+is preserved and the parser ignores it via `ctype_space()`.
+
+| Input                  | Output  | Notes |
+|------------------------|---------|-------|
+| `'1'`                  | `true`  | atom |
+| `'0'`                  | `false` | atom |
+| `'1 && 1'`             | `true`  | AND, double operator |
+| `'1 & 1'`              | `true`  | AND, single operator (regex preserves `&`) |
+| `'0 || 1'`             | `true`  | OR, double operator |
+| `'0 | 1'`              | `true`  | OR, single operator (regex preserves `|`) |
+| `'!0'`                 | `true`  | NOT |
+| `'(1 && 0) || 1'`      | `true`  | parentheses + composite |
+| `'1 || 0 && 0'`        | `true`  | precedence: `&&` binds tighter than `||` (must NOT collapse to `(1||0) && 0`) |
+| `'!(0 || (1 && !1))'`  | `true`  | nested NOT + parentheses |
+| invalid (e.g. `'&&&'`) | throws  | `\InvalidArgumentException` with the original user-facing message |
+
+### `hasAccess()` end-to-end (extract — full set lives in `UserAccessTest`)
+
+Given a fixture user with `hasPermission('read') === true`,
+`hasPermission('write') === true`, all other permissions `false`, and
+`isAdministrator() === false`:
+
+| Expression                                  | Result  |
+|---------------------------------------------|---------|
+| `'read'`                                    | `true`  |
+| `'admin'`                                   | `false` |
+| `'read && write'`                           | `true`  |
+| `'read & write'`                            | `true`  |
+| `'read || admin'`                           | `true`  |
+| `'admin || superadmin'`                     | `false` |
+| `'!admin'`                                  | `true`  |
+| `'(read && write) || admin'`                | `true`  |
+| `'read && (write || admin)'`                | `true`  |
+| `'(read || admin) && (write || superadmin)'`| `true`  |
+| `''` / `null`                               | `true` (early exit) |
+| `'&&& invalid'`                             | throws `\InvalidArgumentException` |
+| administrator + `'admin && write'`          | `true` (administrator short-circuit, even with zero permissions) |
+
+---
+
+## 📚 Out-of-Scope (Deferred — flagged with ROADMAP IDs)
+
+| Concern                                                                                       | Tracked in |
+|-----------------------------------------------------------------------------------------------|------------|
+| `EntityManager` singleton, `ModelServiceLocator` / `IntlServiceLocator` static service locators | Step 2.1.6 (PHPStan Level 7→8) |
+| ORM `Metadata` / `Relation` / `PropertyTrait` typing gaps                                     | Step 2.1.6 |
+| `#[AllowDynamicProperties]` on `Node` / `Widget`                                              | Step 2.1.6 |
+| Extracting `evaluateBooleanExpression()` into a standalone `PermissionExpressionEvaluator` service | Step 2.5 (Extension Safety System) — only if a future caller needs it; today it has exactly one caller, so per Rules 1 + 2 it stays inline |
+| `strict_types` audit across the rest of the codebase                                          | Step 2.1.3 (`strict_types` Migration) |
+| CSP / `eval()` ban as a project-wide enforcement                                              | Step 1.13.5 (CSP) / Step 4.1 (Basic Security) |
+
+### Phase 1 audit closures
+
+This step closes Phase 1 audit **§1.11 (ORM modernization)** **partially** — only
+the `User::hasAccess()` `create_function()` finding is resolved here. The
+remaining §1.11 findings (listed above) require Step 2.1.6 to also land before
+the audit cell flips from ⚠️ to 🛡️. Per `push.mdc`, partial closures are
+**not** flipped on the ROADMAP audit column in this PR.
+
+---
+
+## 📎 Related Documents
+
+- Plan / TODO-Spec: `.cursor/tickets/PROMPT_2_0_8_User-hasAccess-Hotfix_plan.md`
+- Task Prompt: `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_8_User-hasAccess-Hotfix.md`
+- Phase plan: `.cursor/ROADMAP.md` → Phase 2.0 → Step 2.0.8
+- Previous step: `migration-docs/branches/step-2-0-7-event-bridge-removal.md`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2287,12 +2287,6 @@ parameters:
 			path: app/system/modules/user/src/Model/User.php
 
 		-
-			message: '#^Function create_function not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: app/system/modules/user/src/Model/User.php
-
-		-
 			message: '#^Method Pagekit\\User\\Model\\User\:\:create\(\) should return static\(Pagekit\\User\\Model\\User\) but returns object\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ROADMAP **Step 2.0.8** — Foundation Consolidation hotfix. Replaces the
PHP-8-incompatible `create_function()` call inside
`Pagekit\User\Model\User::hasAccess()` with a safe, pure-PHP recursive-descent
boolean expression evaluator. Closes #185.

`create_function()` was deprecated in PHP 7.2 and **removed in PHP 8.0**.
Pagekit declares `"php": "^8.2"`, so on every non-trivial permission check
(anything containing `&`, `|`, `(`, `)`, or `!`) the previous code would
have produced a fatal `Call to undefined function create_function()`. The
simple-permission and administrator short-circuits masked the regression in
trivial paths, but the moment any composite expression hit the fall-through
— e.g. `read && write`, `(admin || editor) && publish` — the entire
authorization stack would have crashed.

## What changed

- **`app/system/modules/user/src/Model/User.php`**
  - `hasAccess()` now calls a new `private static evaluateBooleanExpression(string $exp): bool`
    helper, wrapped in `try { … } catch (\Throwable) { … }` that re-throws a
    clean `\InvalidArgumentException` with the original user-facing message.
  - The `create_function()` block is **physically deleted** (no shim, no
    adapter, no PHP-version branch — Rule 4: DELETE OVER WRAP).
  - The new evaluator is a recursive-descent parser with grammar
    `expr → orExpr → andExpr → notExpr → atom`, accepts both single
    (`&`, `|`) and double (`&&`, `||`) operators, and enforces precedence
    `!` > `&&` > `||`.
  - **No `eval()`**, no `Closure::fromCallable`, no `assert()`, no Symfony
    `ExpressionLanguage` dependency.
  - Early-exit logic (`isAdministrator() || empty()`), simple-permission
    short-circuit (`!preg_match('/[&\(\)\|\!]/', $expression)`), and the
    regex reduction producing `$exp` are unchanged.
- **`phpstan-baseline.neon`** — removed the now-stale
  `Function create_function not found.` ignore entry scoped to `User.php`
  (the suppression is part of the deletion).
- **`app/system/modules/user/src/Tests/UserAccessTest.php`** — **new file**,
  37 unit tests, no DB / container / kernel bootstrap.
- **Branch documentation, version bump, CHANGELOG, ROADMAP, ticket** — see commits below.

## No-Mercy compliance

| Rule | Outcome |
|------|---------|
| Rule 1 — No Compatibility Layers | ✅ No `eval()`, no `Closure::fromCallable`, no `assert()`, no `ExpressionLanguage`, no PHP-version branch |
| Rule 2 — No Adapters | ✅ Single `private static` method on `User` (one caller) — no service class, no trait, no facade |
| Rule 3 — Breaking Changes Allowed Internally | ✅ Public `User::hasAccess()` signature + behaviour for valid expressions is identical; the fatal-on-PHP-8 path is fixed |
| Rule 4 — Delete Over Wrap | ✅ `create_function()` block physically deleted; PHPStan baseline entry pruned alongside |
| Rule 5 — Mandatory Flagging | ✅ No new in-code TODOs needed; deferrals documented in branch doc + architect plan |

## Test results

- ✅ `./app/vendor/bin/phpunit` — **326 tests, 765 assertions, 0 failures, 0 errors** (was 289 before this step; +37 new `UserAccessTest` cases)
- ✅ `./app/vendor/bin/phpstan analyse --no-progress --memory-limit=512M` — `[OK] No errors`
- ✅ `php pagekit setup` — clean
- ✅ `php pagekit list` — Pagekit 1.2.13, all commands listed
- ✅ Playwright (chromium): `installation.spec.js` (1/1), `authentication.spec.js` (14/14), `dashboard.spec.js` (10/10) — login flow exercises the authorization stack, closest production-shaped smoke test for `hasAccess()`
- ✅ `rg "create_function" app/ packages/ --glob "*.php"` → 0 functional hits (one docblock mention only)
- ✅ `rg "eval\s*\(" app/system/modules/user/src/Model/User.php` → 0 functional hits

## Commits

| SHA        | Subject |
|------------|---------|
| `f99ac338` | `fix(user): replace create_function with safe boolean evaluator` |
| `890c1c97` | `test(user): add UserAccessTest for boolean evaluator and hasAccess` |
| `3ed96ca8` | `docs(step-2-0-8): add branch documentation for User::hasAccess hotfix` |
| `e92d8aab` | `chore(release): bump version to 1.2.13` |
| `8605583d` | `docs(roadmap): close Step 2.0.8` |
| `42fcfcb5` | `docs(tickets): add architect plan for step 2.0.8` |

## Phase 1 audit closure (partial)

This step closes Phase 1 audit **§1.11 (ORM modernization)** **partially** —
only the `User::hasAccess()` `create_function()` finding is resolved here.
The remaining §1.11 findings (`EntityManager` singleton,
`ModelServiceLocator` / `IntlServiceLocator` static service locators, ORM
`Metadata` / `Relation` / `PropertyTrait` typing gaps,
`#[AllowDynamicProperties]` on `Node` / `Widget`) are deferred to **Step 2.1.6**
(PHPStan Level 7→8). Per `push.mdc`, partial closures are **not** flipped
on the ROADMAP audit column in this PR — §1.11 stays ⚠️.

## Out-of-scope (deferred)

| Concern | Tracked in |
|---------|------------|
| Remaining §1.11 ORM-modernization findings | Step 2.1.6 |
| Extracting `evaluateBooleanExpression()` into a service class | Step 2.5 (Extension Safety System) — only if a future caller materialises |
| Project-wide `strict_types` audit | Step 2.1.3 |
| CSP / `eval()` ban project-wide | Step 1.13.5 / Step 4.1 |

## Related

- ROADMAP: [`.cursor/ROADMAP.md`](../blob/develop/.cursor/ROADMAP.md) → Phase 2.0 → Step 2.0.8
- Architect plan: `.cursor/tickets/PROMPT_2_0_8_User-hasAccess-Hotfix_plan.md`
- Branch doc: `migration-docs/branches/step-2-0-8-user-hasaccess-hotfix.md`
- Task prompt: `migration-docs/TODO/agent_prompts/Step-2_0-Foundation-Consolidation/PROMPT_2_0_8_User-hasAccess-Hotfix.md`

Closes #185

<!-- metadata
labels: phase-2, fix, security, backend
milestone: Phase 2: Developer Experience
closes: #185
-->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d93c071-8927-489f-9ed2-9f462a0860e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d93c071-8927-489f-9ed2-9f462a0860e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

