### PR TITLE
docs(agents): align architect template with CI-driven final test

### DIFF
--- a/.cursor/agents/architect.md
+++ b/.cursor/agents/architect.md
@@ -32,8 +32,8 @@ Write the plan to a **ticket file** so the Orchestrator and other subagents use 
 - **Checklist:** [1. ..., 2. ..., 3. ...]
 
 ## TESTING STRATEGY
-- **Per step:** PHPUnit + PHPStan (mandatory after every checklist step)
-- **Final run (after all steps):** PHPUnit + PHPStan + `php pagekit setup` + `php pagekit list` + Playwright E2E (installation, login, dashboard)
+- **Per step (Tester subagent):** PHPUnit + PHPStan (mandatory after every checklist step)
+- **Final run (after Early Push, Tester subagent):** wait on the four PHP Quality CI jobs (`phpunit (8.2)`, `phpunit (8.3)`, `phpstan`, `cs-fixer`, `security-audit`) via `gh run watch` and run the 3 Playwright E2E specs locally **in parallel**; both must pass. See `.cursor/agents/tester.md` § End-of-ticket tests for the exact commands and `.cursor/rules/orchestrator-subagent-workflow.mdc` § Final Test for the workflow position.
 ```
 
 - **Chat output:** One line only, e.g. `Plan written to .cursor/tickets/PSR-11-Container-DI-Infrastructure_plan.md`.

--- a/.cursor/rules/orchestrator-subagent-workflow.mdc
+++ b/.cursor/rules/orchestrator-subagent-workflow.mdc
@@ -69,7 +69,7 @@ Plans live in `.cursor/tickets/{task-slug}_plan.md` (`task-slug` = task prompt f
 | **Refactorer**                  | "Ticket: `.cursor/tickets/{task-slug}_plan.md`, Checklist Step N. Delegate to **refactorer**."                                   |
 | **Verifier**                    | "Ticket: `.cursor/tickets/{task-slug}_plan.md`, Checklist Step N. Changed files: [list]. Delegate to **verifier**."              |
 | **Tester** (per Checklist Step) | "Delegate to **tester**. Run: PHPUnit + PHPStan."                                                                                |
-| **Tester** (final)              | "Delegate to **tester**. Final test run: PHPUnit + PHPStan + `php pagekit setup` + `php pagekit list` + Playwright E2E."         |
+| **Tester** (final)              | "Delegate to **tester**. Final test run: wait on CI (gh run watch on the four PHP Quality jobs) + Playwright E2E locally in parallel." |
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Two stale references to the pre-2.1.2 final-test wording were missed by 80dda37f (the workflow refactor in PR #199). The Architect uses one of them — `.cursor/agents/architect.md` — as the literal template for the TESTING STRATEGY block of every ticket plan. The first cloud-agent invocation for Step 2.1.3 emitted the old wording verbatim:

> Final run (after all steps): PHPUnit + PHPStan + \`php pagekit setup\` + \`php pagekit list\` + Playwright E2E

instead of the new CI-driven version.

## Changes

- **`.cursor/agents/architect.md`** — TESTING STRATEGY template updated:
  - Per step: PHPUnit + PHPStan (unchanged, matches Tester per-step responsibility)
  - Final run: wait on the four PHP Quality CI jobs (`phpunit (8.2)`, `phpunit (8.3)`, `phpstan`, `cs-fixer`, `security-audit`) via `gh run watch` + Playwright E2E locally **in parallel**
- **`.cursor/rules/orchestrator-subagent-workflow.mdc`** — Handoff Format table row "Tester (final)" updated to the matching delegation message.

Historical ticket plans (`.cursor/tickets/PROMPT_2_0_*`), the 2.1.2 ticket plan, the audit report, and old CHANGELOG entries are **intentionally NOT touched** — they reflect the workflow that was in force when they were executed.

## Impact on in-flight 2.1.3 cloud-agent run

Zero — the Final Test will execute the architect's verbatim instructions (local PHPUnit + PHPStan + setup + list + Playwright). That wastes a few CI minutes (CI runs anyway on Early Push) and a small amount of local compute on the agent VM, but produces the same PASS/FAIL signal. From PR #201 onward the architect copies the corrected template and the redundant local re-run goes away.

## Test plan

- [x] Local lint: `ReadLints` clean on both files
- [x] `git diff --stat`: 2 files, +3 / -3 lines
- [x] `phpstan-baseline.neon` not touched (docs-only PR)
- [ ] CI: all 5 PHP Quality jobs green (auto-runs on push)
- [ ] Bugbot: no findings on docs-only diff

<!-- metadata
labels: phase-2, documentation
milestone: Phase 2: Developer Experience
-->