### PR TITLE
fix: strict-typing runtime regressions (ORM relations, view scripts, debug collector)

### DIFF
--- a/.cursor/ROADMAP.md
+++ b/.cursor/ROADMAP.md
@@ -1,6 +1,6 @@
 # **🗺️ Pagekit Modernization Roadmap & Rules**
 
-> **Current Version**: 1.2.18
+> **Current Version**: 1.2.19
 > **Current Step**: 2.1.5 (PHPStan Level 6→7 — Null Safety)
 
 ## **💀 THE 5 AGGRESSIVE RULES (NO MERCY)**

--- a/CHANGELOG-NEW.md
+++ b/CHANGELOG-NEW.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Pagekit 1.2.19 - Strict-Typing Runtime Regression Fixes (Juni 21, 2026)
+
+### Fixed
+
+- **ORM single-entity relations crashed on typed nullable properties** — `Relation::initRelation()` seeded `BelongsTo` / `HasOne` relations with the legacy `false` sentinel. After Step 2.1.4 typed the relation properties (e.g. `Post::$user` → `?Pagekit\User\Model\User`), assigning `false` threw `TypeError: Cannot assign false to property … of type ?User` on every blog post list / Post API request (`PostApiController::indexAction()`). The default is now `null` — the natural empty value for a nullable single-entity relation. Collection relations (`HasMany` / `ManyToMany`) are unaffected; they explicitly pass `[]`.
+- **`$view->script()` rejected string dependencies at 13 call sites** — the strict `array $dependencies` parameter (Step 2.1.4) raised `TypeError: Argument #3 ($dependencies) must be of type array, string given` whenever a page registered a script with a bare string dependency. Affected: cache + mail settings (`'settings'`), theme-one site/node/widget editors (`'site-settings'` / `'site-edit'` / `'widget-edit'`), and blog/info/user/permission views (`'vue'`). All wrapped in arrays (`['settings']`, `['vue']`, …). No compatibility shim added — every call site was updated per the No-Mercy rules.
+- **`sha1(int)` TypeError in the debug `RoutesDataCollector`** — `sha1(filemtime(...))` passed an `int` (and potentially `false`) where PHP 8.2's `sha1()` requires `string`, throwing on every request while the debug bar was active. The value is now cast to `(string)`; the matching `sha1` entry was removed from `phpstan-baseline.neon`.
+
+### Notes
+
+- All three regressions were introduced by the strict-typing work in Step 2.1.4 (PR #203) and only surfaced at runtime on admin/blog pages that PHPUnit, PHPStan, and CS-Fixer do not exercise — a coverage gap that admin-facing Playwright E2E tests would catch.
+
 ## Pagekit 1.2.18 - TODO Inventory & Legacy Cleanup (Juni 20, 2026)
 
 ### Security

--- a/app/modules/database/src/ORM/Relation/Relation.php
+++ b/app/modules/database/src/ORM/Relation/Relation.php
@@ -75,9 +75,13 @@ abstract class Relation
     /**
      * Initialize the relationship
      *
+     * Single-entity relations (BelongsTo/HasOne) default to null: their typed
+     * target properties are nullable (?Entity) and cannot hold the legacy false
+     * sentinel. Collection relations (HasMany/ManyToMany) pass an empty array.
+     *
      * @param array<int, object> $entities
      */
-    protected function initRelation(array $entities, mixed $default = false): void
+    protected function initRelation(array $entities, mixed $default = null): void
     {
         foreach ($entities as $entity) {
             $this->metadata->setValue($entity, $this->name, $default);

--- a/app/modules/debug/src/DataCollector/RoutesDataCollector.php
+++ b/app/modules/debug/src/DataCollector/RoutesDataCollector.php
@@ -43,7 +43,7 @@ class RoutesDataCollector implements DataCollectorInterface
      */
     public function collect(): array
     {
-        $path = sprintf($this->cache.'/'.$this->file, sha1(filemtime((new \ReflectionClass($this->router->getGenerator()))->getFileName())));
+        $path = sprintf($this->cache.'/'.$this->file, sha1((string) filemtime((new \ReflectionClass($this->router->getGenerator()))->getFileName())));
 
         if (!file_exists($path)) {
 

--- a/app/system/config.php
+++ b/app/system/config.php
@@ -6,7 +6,7 @@ return [
 
     'application' => [
 
-        'version' => '1.2.18',
+        'version' => '1.2.19',
 
     ],
 

--- a/app/system/modules/cache/index.php
+++ b/app/system/modules/cache/index.php
@@ -60,7 +60,7 @@ return [
 
             $view->data('$caches', $caches);
             $view->data('$settings', ['config' => [$this->name => $this->config(['caches.cache.storage', 'nocache'])]]);
-            $view->script('settings-cache', 'app/system/modules/cache/app/bundle/settings.js', 'settings');
+            $view->script('settings-cache', 'app/system/modules/cache/app/bundle/settings.js', ['settings']);
 
         },
 

--- a/app/system/modules/info/views/info.php
+++ b/app/system/modules/info/views/info.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('info', 'app/system/modules/info/app/bundle/info.js', 'vue') ?>
+$view->script('info', 'app/system/modules/info/app/bundle/info.js', ['vue']) ?>
 
 <div id="info" class="pk-grid-large" uk-grid v-cloak>
     <div class="pk-width-sidebar">

--- a/app/system/modules/mail/index.php
+++ b/app/system/modules/mail/index.php
@@ -96,7 +96,7 @@ return [
         'view.system:modules/settings/views/settings' => function ($event, $view) use ($app) {
             $view->data('$mail', ['ssl' => extension_loaded('openssl')]);
             $view->data('$settings', ['options' => [$this->name => $this->config]]);
-            $view->script('settings-mail', 'app/system/modules/mail/app/bundle/settings.js', 'settings');
+            $view->script('settings-mail', 'app/system/modules/mail/app/bundle/settings.js', ['settings']);
         },
 
     ],

--- a/app/system/modules/user/views/admin/permission-index.php
+++ b/app/system/modules/user/views/admin/permission-index.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('permission-index', 'system/user:app/bundle/permission-index.js', 'vue') ?>
+$view->script('permission-index', 'system/user:app/bundle/permission-index.js', ['vue']) ?>
 
 <div id="permissions" v-cloak>
 

--- a/packages/pagekit/blog/views/admin/settings.php
+++ b/packages/pagekit/blog/views/admin/settings.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('blog-settings', 'blog:app/bundle/settings.js', 'vue') ?>
+$view->script('blog-settings', 'blog:app/bundle/settings.js', ['vue']) ?>
 
 <div id="settings" class="uk-form-horizontal" v-cloak>
 

--- a/packages/pagekit/blog/views/comments.php
+++ b/packages/pagekit/blog/views/comments.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('comments', 'blog:app/bundle/comments.js', 'vue') ?>
+$view->script('comments', 'blog:app/bundle/comments.js', ['vue']) ?>
 
 <div id="comments" v-cloak></div>
 

--- a/packages/pagekit/blog/views/post.php
+++ b/packages/pagekit/blog/views/post.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('post', 'blog:app/bundle/post.js', 'vue') ?>
+$view->script('post', 'blog:app/bundle/post.js', ['vue']) ?>
 
 <article class="uk-article">
 

--- a/packages/pagekit/blog/views/posts.php
+++ b/packages/pagekit/blog/views/posts.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('posts', 'blog:app/bundle/posts.js', 'vue') ?>
+$view->script('posts', 'blog:app/bundle/posts.js', ['vue']) ?>
 
 <?php foreach ($posts as $post) : ?>
 <article class="uk-article">

--- a/packages/pagekit/theme-one/index.php
+++ b/packages/pagekit/theme-one/index.php
@@ -156,17 +156,17 @@ return [
     'events' => [
 
         'view.system/site/admin/settings' => function ($event, $view) use ($app) {
-            $view->script('site-theme', 'theme:app/bundle/site-theme.js', 'site-settings');
+            $view->script('site-theme', 'theme:app/bundle/site-theme.js', ['site-settings']);
             $view->data('$theme', $this);
         },
 
         'view.system/site/admin/edit' => function ($event, $view) {
-            $view->script('node-theme', 'theme:app/bundle/node-theme.js', 'site-edit');
+            $view->script('node-theme', 'theme:app/bundle/node-theme.js', ['site-edit']);
             $view->data('$theme', $this->options);
         },
 
         'view.system/widget/edit' => function ($event, $view) {
-            $view->script('widget-theme', 'theme:app/bundle/widget-theme.js', 'widget-edit');
+            $view->script('widget-theme', 'theme:app/bundle/widget-theme.js', ['widget-edit']);
         },
 
         /**

--- a/packages/pagekit/theme-one/views/blog/post.php
+++ b/packages/pagekit/theme-one/views/blog/post.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('post', 'blog:app/bundle/post.js', 'vue') ?>
+$view->script('post', 'blog:app/bundle/post.js', ['vue']) ?>
 
 <article class="uk-article tm-container-small">
 

--- a/packages/pagekit/theme-one/views/blog/posts.php
+++ b/packages/pagekit/theme-one/views/blog/posts.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-$view->script('posts', 'blog:app/bundle/posts.js', 'vue') ?>
+$view->script('posts', 'blog:app/bundle/posts.js', ['vue']) ?>
 
 <div class="tm-container-small">
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -493,12 +493,6 @@ parameters:
 			path: app/modules/debug/index.php
 
 		-
-			message: '#^Parameter \#1 \$string of function sha1 expects string, int\<0, max\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/modules/debug/src/DataCollector/RoutesDataCollector.php
-
-		-
 			message: '#^Return type \(void\) of method Pagekit\\Debug\\Middleware\\DebugStatement\:\:bindParam\(\) should be compatible with return type \(bool\) of method Doctrine\\DBAL\\Driver\\Middleware\\AbstractStatementMiddleware\:\:bindParam\(\)$#'
 			identifier: method.childReturnType
 			count: 1


### PR DESCRIPTION
## Summary

Fixes three runtime `TypeError`s introduced by the strict-typing work in **Step 2.1.4 (PR #203)**. None were caught by PHPUnit / PHPStan / CS-Fixer because they only trigger on admin/blog pages exercised at runtime, not in the unit suite. Surfaced via `tmp/logs/debug.log` (entries from 2026-06-20).

## Root cause & fixes

- **ORM (`fix(orm)`)** — `Relation::initRelation()` seeded `BelongsTo` / `HasOne` with the legacy `false` sentinel. Once `Post::$user` became `?Pagekit\User\Model\User` (Step 2.1.4), assigning `false` threw `Cannot assign false to property … of type ?User` on every blog list / Post API request. Default is now `null`; `HasMany` / `ManyToMany` unaffected (they pass `[]`).
- **View (`fix(view)`)** — the strict `array $dependencies` parameter on `$view->script()` rejected bare string dependencies at **13 call sites** (`'settings'`, `'site-settings'`, `'site-edit'`, `'widget-edit'`, `'vue'`). All wrapped in arrays. No shim — call sites updated directly per the No-Mercy rules.
- **Debug (`fix(debug)`)** — `sha1(filemtime(...))` passed `int|false` where PHP 8.2 `sha1()` requires `string`; cast to `(string)`. Obsolete `sha1` entry removed from `phpstan-baseline.neon` (prevents baseline drift).

## Test plan

- [x] `./app/vendor/bin/phpstan analyse --no-progress` → **No errors** (no baseline drift)
- [x] `./app/vendor/bin/phpunit` → **326 tests, 752 assertions, 0 failures**
- [x] Manual: open blog post list / Post API, cache + mail settings, and a page with the debug bar active → no `TypeError` in `tmp/logs/debug.log`

## Follow-up

- The recurring `attempt to write a readonly database` entries in `debug.log` are **environmental** (SQLite/`tmp/` write permissions), not a code bug — not addressed here.
- Coverage gap: admin-facing Playwright E2E would have caught all three. Candidate for a future test step.

<!-- metadata -->
<!-- labels: bug, backend, database, module, theme, phase-2 -->
<!-- milestone: Phase 2: Developer Experience -->
<!-- version: 1.2.19 -->