### PR TITLE
chore(agents): upgrade architect and refactorer to opus 4.8 max

### DIFF
--- a/.cursor/WORKFLOW_SUBAGENTS.md
+++ b/.cursor/WORKFLOW_SUBAGENTS.md
@@ -100,10 +100,19 @@ Your four agents are **correctly set up** for Cursor:
 - **Format:** Markdown with YAML frontmatter: `name`, `description`, and optionally `model`.
 - **Names:** `architect`, `refactorer`, `verifier`, `tester` – these are the names the orchestrator rule uses for delegation.
 
+**Current model assignments** (see each agent’s YAML frontmatter in `.cursor/agents/`):
+
+| Agent | Model | Role |
+| ----- | ----- | ---- |
+| `architect` | `claude-opus-4-8[thinking=true,context=1m,effort=max,fast=false]` | Strategic planning (Opus 4.8 Max) |
+| `refactorer` | `claude-opus-4-8[thinking=true,context=1m,effort=max,fast=false]` | Code changes (Opus 4.8 Max) |
+| `verifier` | `claude-opus-4-6` | Static audit |
+| `tester` | `claude-sonnet-4-6` | Test execution |
+
 Optional tweaks:
 
-- **Verifier** has no `model` in frontmatter; others use `claude-4.5-opus-high-thinking`. You can add a `model` line to `verifier.md` if you want to fix the model there too.
 - **Descriptions** are already clear for when the main agent chooses which subagent to call.
+- To change a model, edit the `model:` line in the agent’s frontmatter; keep this table in sync.
 
 No structural changes are required for “how to create or control” them: **control** is done by the **orchestrator rule** and by **your invocation message** (task prompt + “execute with Orchestrator workflow”).
 

--- a/.cursor/agents/architect.md
+++ b/.cursor/agents/architect.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-model: claude-opus-4-7
+model: claude-opus-4-8[thinking=true,context=1m,effort=max,fast=false]
 description: Strategic Lead for Pagekit modernization. Maps task prompts to ROADMAP.md, defines scope, checklist, TODO-Spec. Use proactively when executing agent_prompts or task prompts from the modernization plan.
 ---
 

--- a/.cursor/agents/refactorer.md
+++ b/.cursor/agents/refactorer.md
@@ -1,6 +1,6 @@
 ---
 name: refactorer
-model: claude-opus-4-7
+model: claude-opus-4-8[thinking=true,context=1m,effort=max,fast=false]
 description: No Mercy Code Engineer for Pagekit modernization. Executes Architect's plan with direct replacement, no shims. Use when implementing refactoring steps from the Architect's checklist.
 ---
 


### PR DESCRIPTION
## Summary

- Upgrade **architect** and **refactorer** subagents from `claude-opus-4-7` to Opus 4.8 Max (`claude-opus-4-8[thinking=true,context=1m,effort=max,fast=false]`).
- Update `WORKFLOW_SUBAGENTS.md` with a current model-assignment table (architect/refactorer, verifier, tester) and remove stale `claude-4.5-opus-high-thinking` guidance.

## Test plan

- [x] Open `.cursor/agents/architect.md` and `refactorer.md` — confirm `model:` frontmatter matches Cursor’s Opus 4.8 Max slug.
- [x] Delegate to architect/refactorer in Orchestrator workflow — confirm the correct subagent model is used (not 4.7).

<!-- metadata
labels: phase-2, migration
milestone: Phase 2: Developer Experience
-->