### PR TITLE
chore(cloud): update agent environment snapshot

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.cursor.com/schemas/environment.schema.json",
-  "snapshot": "snapshot-20260620-594c3358-d9b9-48f0-8dce-ade41de79a21",
+  "snapshot": "snapshot-20260623-02d9a84b-5aed-4f66-8974-4b2393848ce7",
   "install": "bash .cursor/install.sh",
   "start": "bash .cursor/start.sh",
   "terminals": []


### PR DESCRIPTION
## Summary
- Bumps the Cursor Cloud Agent environment snapshot referenced in `.cursor/environment.json`.
- `snapshot-20260620-594c3358-...` → `snapshot-20260623-02d9a84b-...`

This only changes which prebuilt environment image new cloud agents (including Bugbot on PRs) boot from; no application or build code is affected.

## Test plan
- [x] A fresh Cloud Agent / Bugbot run boots from the new snapshot without install/start errors (`.cursor/install.sh`, `.cursor/start.sh`).